### PR TITLE
调整画中画窗口的标题栏大小，使其更易拖动

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,31 +1,34 @@
 ﻿root = true
 
 [*]
-end_of_line          = lf
-charset              = utf-8-bom
-indent_style         = space
-indent_size          = 4
+end_of_line = lf
+charset = utf-8-bom
+indent_style = space
+indent_size = 4
 insert_final_newline = true
 
 [*.{xml,xaml}]
 
 [*.{cs,vb}]
 # async methods end in Async
-dotnet_naming_symbols.method_symbols.applicable_kinds         = method
-dotnet_naming_symbols.method_symbols.required_modifiers       = async
+dotnet_naming_symbols.method_symbols.applicable_kinds = method
+dotnet_naming_symbols.method_symbols.required_modifiers = async
 
-dotnet_naming_style.end_in_async_style.capitalization         = pascal_case
-dotnet_naming_style.end_in_async_style.required_suffix        = Async
+dotnet_naming_style.end_in_async_style.capitalization = pascal_case
+dotnet_naming_style.end_in_async_style.required_suffix = Async
 
 dotnet_naming_rule.async_methods_must_end_with_async.severity = warning
-dotnet_naming_rule.async_methods_must_end_with_async.symbols  = method_symbols
-dotnet_naming_rule.async_methods_must_end_with_async.style    = end_in_async_style
+dotnet_naming_rule.async_methods_must_end_with_async.symbols = method_symbols
+dotnet_naming_rule.async_methods_must_end_with_async.style = end_in_async_style
 
-dotnet_style_qualification_for_event                          = false : suggestion
-dotnet_style_qualification_for_field                          = false : suggestion
-dotnet_style_qualification_for_method                         = false : suggestion
-dotnet_style_qualification_for_property                       = false : suggestion
+dotnet_style_qualification_for_event = false : suggestion
+dotnet_style_qualification_for_field = false : suggestion
+dotnet_style_qualification_for_method = false : suggestion
+dotnet_style_qualification_for_property = false : suggestion
 
 [*.cs]
 csharp_indent_switch_labels = true
 csharp_indent_case_contents = true
+csharp_style_var_when_type_is_apparent = true : suggestion
+csharp_style_var_for_built_in_types = false : none
+csharp_style_var_elsewhere = true : suggestion

--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line          = lf
+charset              = utf-8
+indent_style         = space
+indent_size          = 4
+insert_final_newline = true
+
+[*.{xml,xaml}]
+
+[*.cs]
+csharp_indent_switch_labels = true
+csharp_indent_case_contents = true

--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,13 +1,30 @@
-root = true
+﻿root = true
 
 [*]
 end_of_line          = lf
-charset              = utf-8
+charset              = utf-8-bom
 indent_style         = space
 indent_size          = 4
 insert_final_newline = true
 
 [*.{xml,xaml}]
+
+[*.{cs,vb}]
+# async methods end in Async
+dotnet_naming_symbols.method_symbols.applicable_kinds         = method
+dotnet_naming_symbols.method_symbols.required_modifiers       = async
+
+dotnet_naming_style.end_in_async_style.capitalization         = pascal_case
+dotnet_naming_style.end_in_async_style.required_suffix        = Async
+
+dotnet_naming_rule.async_methods_must_end_with_async.severity = warning
+dotnet_naming_rule.async_methods_must_end_with_async.symbols  = method_symbols
+dotnet_naming_rule.async_methods_must_end_with_async.style    = end_in_async_style
+
+dotnet_style_qualification_for_event                          = false : suggestion
+dotnet_style_qualification_for_field                          = false : suggestion
+dotnet_style_qualification_for_method                         = false : suggestion
+dotnet_style_qualification_for_property                       = false : suggestion
 
 [*.cs]
 csharp_indent_switch_labels = true

--- a/Source/Aurora.Music.PlaybackEngine/Player.cs
+++ b/Source/Aurora.Music.PlaybackEngine/Player.cs
@@ -1,4 +1,4 @@
-﻿using Aurora.Music.Core;
+using Aurora.Music.Core;
 using Aurora.Music.Core.Models;
 using Aurora.Music.Core.Storage;
 using Aurora.Music.Effects;
@@ -209,19 +209,19 @@ namespace Aurora.Music.PlaybackEngine
 
             switch (mediaPlayer.PlaybackSession.PlaybackState)
             {
-            case MediaPlaybackState.None:
-            case MediaPlaybackState.Opening:
-            case MediaPlaybackState.Buffering:
-                isPlaying = null;
-                break;
-            case MediaPlaybackState.Playing:
-                isPlaying = true;
-                break;
-            case MediaPlaybackState.Paused:
-                isPlaying = false;
-                break;
-            default:
-                break;
+                case MediaPlaybackState.None:
+                case MediaPlaybackState.Opening:
+                case MediaPlaybackState.Buffering:
+                    isPlaying = null;
+                    break;
+                case MediaPlaybackState.Playing:
+                    isPlaying = true;
+                    break;
+                case MediaPlaybackState.Paused:
+                    isPlaying = false;
+                    break;
+                default:
+                    break;
             }
 
             PlaybackStatusChanged?.Invoke(this, new PlaybackStatusChangedArgs()
@@ -236,19 +236,19 @@ namespace Aurora.Music.PlaybackEngine
         {
             switch (mediaPlayer.PlaybackSession.PlaybackState)
             {
-            case MediaPlaybackState.None:
-            case MediaPlaybackState.Opening:
-            case MediaPlaybackState.Buffering:
-                isPlaying = null;
-                break;
-            case MediaPlaybackState.Playing:
-                isPlaying = true;
-                break;
-            case MediaPlaybackState.Paused:
-                isPlaying = false;
-                break;
-            default:
-                break;
+                case MediaPlaybackState.None:
+                case MediaPlaybackState.Opening:
+                case MediaPlaybackState.Buffering:
+                    isPlaying = null;
+                    break;
+                case MediaPlaybackState.Playing:
+                    isPlaying = true;
+                    break;
+                case MediaPlaybackState.Paused:
+                    isPlaying = false;
+                    break;
+                default:
+                    break;
             }
 
             var currentSong = mediaPlaybackList.CurrentItem?.Source.CustomProperties[Consts.SONG] as Song;
@@ -524,18 +524,18 @@ namespace Aurora.Music.PlaybackEngine
         {
             switch (mediaPlayer.PlaybackSession.PlaybackState)
             {
-            case MediaPlaybackState.Playing:
-                Pause();
-                break;
-            case MediaPlaybackState.None:
-            case MediaPlaybackState.Opening:
-            case MediaPlaybackState.Buffering:
-            case MediaPlaybackState.Paused:
-                Play();
-                break;
-            default:
-                Play();
-                break;
+                case MediaPlaybackState.Playing:
+                    Pause();
+                    break;
+                case MediaPlaybackState.None:
+                case MediaPlaybackState.Opening:
+                case MediaPlaybackState.Buffering:
+                case MediaPlaybackState.Paused:
+                    Play();
+                    break;
+                default:
+                    Play();
+                    break;
             }
         }
 

--- a/Source/Aurora.Music.PlaybackEngine/Player.cs
+++ b/Source/Aurora.Music.PlaybackEngine/Player.cs
@@ -209,19 +209,19 @@ namespace Aurora.Music.PlaybackEngine
 
             switch (mediaPlayer.PlaybackSession.PlaybackState)
             {
-                case MediaPlaybackState.None:
-                case MediaPlaybackState.Opening:
-                case MediaPlaybackState.Buffering:
-                    isPlaying = null;
-                    break;
-                case MediaPlaybackState.Playing:
-                    isPlaying = true;
-                    break;
-                case MediaPlaybackState.Paused:
-                    isPlaying = false;
-                    break;
-                default:
-                    break;
+            case MediaPlaybackState.None:
+            case MediaPlaybackState.Opening:
+            case MediaPlaybackState.Buffering:
+                isPlaying = null;
+                break;
+            case MediaPlaybackState.Playing:
+                isPlaying = true;
+                break;
+            case MediaPlaybackState.Paused:
+                isPlaying = false;
+                break;
+            default:
+                break;
             }
 
             PlaybackStatusChanged?.Invoke(this, new PlaybackStatusChangedArgs()
@@ -236,19 +236,19 @@ namespace Aurora.Music.PlaybackEngine
         {
             switch (mediaPlayer.PlaybackSession.PlaybackState)
             {
-                case MediaPlaybackState.None:
-                case MediaPlaybackState.Opening:
-                case MediaPlaybackState.Buffering:
-                    isPlaying = null;
-                    break;
-                case MediaPlaybackState.Playing:
-                    isPlaying = true;
-                    break;
-                case MediaPlaybackState.Paused:
-                    isPlaying = false;
-                    break;
-                default:
-                    break;
+            case MediaPlaybackState.None:
+            case MediaPlaybackState.Opening:
+            case MediaPlaybackState.Buffering:
+                isPlaying = null;
+                break;
+            case MediaPlaybackState.Playing:
+                isPlaying = true;
+                break;
+            case MediaPlaybackState.Paused:
+                isPlaying = false;
+                break;
+            default:
+                break;
             }
 
             var currentSong = mediaPlaybackList.CurrentItem?.Source.CustomProperties[Consts.SONG] as Song;
@@ -524,18 +524,18 @@ namespace Aurora.Music.PlaybackEngine
         {
             switch (mediaPlayer.PlaybackSession.PlaybackState)
             {
-                case MediaPlaybackState.Playing:
-                    Pause();
-                    break;
-                case MediaPlaybackState.None:
-                case MediaPlaybackState.Opening:
-                case MediaPlaybackState.Buffering:
-                case MediaPlaybackState.Paused:
-                    Play();
-                    break;
-                default:
-                    Play();
-                    break;
+            case MediaPlaybackState.Playing:
+                Pause();
+                break;
+            case MediaPlaybackState.None:
+            case MediaPlaybackState.Opening:
+            case MediaPlaybackState.Buffering:
+            case MediaPlaybackState.Paused:
+                Play();
+                break;
+            default:
+                Play();
+                break;
             }
         }
 

--- a/Source/Aurora.Music.sln
+++ b/Source/Aurora.Music.sln
@@ -25,6 +25,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LrcParser", "LrcParser\LrcP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "URIViewer", "URIViewer\URIViewer.csproj", "{8739549D-F443-4863-9ABD-6E64914536C2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0C848A85-F29C-4039-B2A4-C646831F65B6}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		BETA|Any CPU = BETA|Any CPU

--- a/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml
+++ b/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml
@@ -17,368 +17,368 @@ Licensed under the MIT License. See LICENSE in the project root for license info
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
 
-  <Page.Resources>
-    <ResourceDictionary>
-      <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="../Themes/Styles.xaml" />
-      </ResourceDictionary.MergedDictionaries>
-      <ResourceDictionary.ThemeDictionaries>
-        <ResourceDictionary x:Key="Light"
-                            Source="../Themes/Light.xaml" />
-        <ResourceDictionary x:Key="Dark"
-                            Source="../Themes/Dark.xaml" />
-      </ResourceDictionary.ThemeDictionaries>
-    </ResourceDictionary>
-  </Page.Resources>
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Themes/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light"
+                                    Source="../Themes/Light.xaml" />
+                <ResourceDictionary x:Key="Dark"
+                                    Source="../Themes/Dark.xaml" />
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
 
-  <Page.DataContext>
-    <vm:NowPlayingPageViewModel x:Name="Context" />
-  </Page.DataContext>
+    <Page.DataContext>
+        <vm:NowPlayingPageViewModel x:Name="Context" />
+    </Page.DataContext>
 
-  <Grid x:Name="Root"
-        Background="{ThemeResource SystemControlBackgroundBaseHighBrush}">
-    <VisualStateManager.VisualStateGroups>
-      <VisualStateGroup>
-        <VisualState x:Name="Narrow">
-          <VisualState.StateTriggers>
-            <AdaptiveTrigger MinWindowWidth="0" />
-          </VisualState.StateTriggers>
-          <VisualState.Setters>
-            <Setter Target="Previous.Visibility"
-                    Value="Collapsed" />
-            <Setter Target="PlayListFull.Visibility"
-                    Value="Collapsed" />
-            <Setter Target="Artwork.Visibility"
-                    Value="Collapsed" />
-            <Setter Target="ContentPanel.HorizontalAlignment"
-                    Value="Center" />
-            <Setter Target="ButtonPanel.HorizontalAlignment"
-                    Value="Center" />
-          </VisualState.Setters>
-        </VisualState>
+    <Grid x:Name="Root"
+          Background="{ThemeResource SystemControlBackgroundBaseHighBrush}">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="Narrow">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Previous.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="PlayListFull.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="Artwork.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="ContentPanel.HorizontalAlignment"
+                                Value="Center" />
+                        <Setter Target="ButtonPanel.HorizontalAlignment"
+                                Value="Center" />
+                    </VisualState.Setters>
+                </VisualState>
 
-        <VisualState x:Name="Medium">
-          <VisualState.StateTriggers>
-            <AdaptiveTrigger MinWindowWidth="240" />
-          </VisualState.StateTriggers>
-          <VisualState.Setters>
-            <Setter Target="Previous.Visibility"
-                    Value="Collapsed" />
-            <Setter Target="PlayListFull.Visibility"
-                    Value="Visible" />
-            <Setter Target="Artwork.MaxWidth"
-                    Value="200" />
-            <Setter Target="Artwork.Visibility"
-                    Value="Visible" />
-          </VisualState.Setters>
-        </VisualState>
+                <VisualState x:Name="Medium">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="240" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Previous.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="PlayListFull.Visibility"
+                                Value="Visible" />
+                        <Setter Target="Artwork.MaxWidth"
+                                Value="200" />
+                        <Setter Target="Artwork.Visibility"
+                                Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
 
-        <VisualState x:Name="Full">
-          <VisualState.StateTriggers>
-            <AdaptiveTrigger MinWindowWidth="320" />
-          </VisualState.StateTriggers>
-          <VisualState.Setters>
-            <Setter Target="Previous.Visibility"
-                    Value="Visible" />
-            <Setter Target="PlayListFull.Visibility"
-                    Value="Visible" />
-            <Setter Target="Artwork.MaxWidth"
-                    Value="250" />
-            <Setter Target="PlayListFull.Visibility"
-                    Value="Visible" />
-            <Setter Target="Artwork.Visibility"
-                    Value="Visible" />
-          </VisualState.Setters>
-        </VisualState>
-      </VisualStateGroup>
-      <VisualStateGroup>
-        <VisualState x:Name="Short">
-          <VisualState.StateTriggers>
-            <AdaptiveTrigger MinWindowHeight="0" />
-          </VisualState.StateTriggers>
-          <VisualState.Setters>
-            <Setter Target="Description.Visibility"
-                    Value="Collapsed" />
-            <Setter Target="Addtional.Visibility"
-                    Value="Collapsed" />
-            <Setter Target="Title.HorizontalAlignment"
-                    Value="Left" />
-            <Setter Target="ContentPanel.HorizontalAlignment"
-                    Value="Left" />
-            <Setter Target="ButtonPanel.HorizontalAlignment"
-                    Value="Left" />
-            <Setter Target="RowOne.Height"
-                    Value="0" />
-            <Setter Target="RowOne.MinHeight"
-                    Value="0" />
-            <Setter Target="RowTwo.Height"
-                    Value="*" />
-            <Setter Target="RowThree.Height"
-                    Value="*" />
-            <Setter Target="ContentPanel.VerticalAlignment"
-                    Value="Center" />
-            <Setter Target="ButtonPanel.VerticalAlignment"
-                    Value="Center" />
-          </VisualState.Setters>
-        </VisualState>
+                <VisualState x:Name="Full">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="320" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Previous.Visibility"
+                                Value="Visible" />
+                        <Setter Target="PlayListFull.Visibility"
+                                Value="Visible" />
+                        <Setter Target="Artwork.MaxWidth"
+                                Value="250" />
+                        <Setter Target="PlayListFull.Visibility"
+                                Value="Visible" />
+                        <Setter Target="Artwork.Visibility"
+                                Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+            <VisualStateGroup>
+                <VisualState x:Name="Short">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowHeight="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Description.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="Addtional.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="Title.HorizontalAlignment"
+                                Value="Left" />
+                        <Setter Target="ContentPanel.HorizontalAlignment"
+                                Value="Left" />
+                        <Setter Target="ButtonPanel.HorizontalAlignment"
+                                Value="Left" />
+                        <Setter Target="RowOne.Height"
+                                Value="0" />
+                        <Setter Target="RowOne.MinHeight"
+                                Value="0" />
+                        <Setter Target="RowTwo.Height"
+                                Value="*" />
+                        <Setter Target="RowThree.Height"
+                                Value="*" />
+                        <Setter Target="ContentPanel.VerticalAlignment"
+                                Value="Center" />
+                        <Setter Target="ButtonPanel.VerticalAlignment"
+                                Value="Center" />
+                    </VisualState.Setters>
+                </VisualState>
 
-        <VisualState x:Name="Tall">
-          <VisualState.StateTriggers>
-            <AdaptiveTrigger MinWindowHeight="250" />
-          </VisualState.StateTriggers>
-          <VisualState.Setters>
-            <Setter Target="Artwork.Visibility"
-                    Value="Visible" />
-            <Setter Target="Description.Visibility"
-                    Value="Collapsed" />
-            <Setter Target="Addtional.Visibility"
-                    Value="Collapsed" />
-            <Setter Target="Title.FontSize"
-                    Value="20" />
+                <VisualState x:Name="Tall">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowHeight="250" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Artwork.Visibility"
+                                Value="Visible" />
+                        <Setter Target="Description.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="Addtional.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="Title.FontSize"
+                                Value="20" />
 
-            <Setter Target="Artwork.(Grid.Row)"
-                    Value="0" />
-            <Setter Target="Artwork.(Grid.RowSpan)"
-                    Value="1" />
-            <Setter Target="Artwork.(Grid.ColumnSpan)"
-                    Value="2" />
+                        <Setter Target="Artwork.(Grid.Row)"
+                                Value="0" />
+                        <Setter Target="Artwork.(Grid.RowSpan)"
+                                Value="1" />
+                        <Setter Target="Artwork.(Grid.ColumnSpan)"
+                                Value="2" />
 
-            <Setter Target="ButtonPanel.(Grid.ColumnSpan)"
-                    Value="2" />
-            <Setter Target="ContentPanel.(Grid.ColumnSpan)"
-                    Value="2" />
+                        <Setter Target="ButtonPanel.(Grid.ColumnSpan)"
+                                Value="2" />
+                        <Setter Target="ContentPanel.(Grid.ColumnSpan)"
+                                Value="2" />
 
-            <Setter Target="ButtonPanel.(Grid.Column)"
-                    Value="0" />
-            <Setter Target="ContentPanel.(Grid.Column)"
-                    Value="0" />
+                        <Setter Target="ButtonPanel.(Grid.Column)"
+                                Value="0" />
+                        <Setter Target="ContentPanel.(Grid.Column)"
+                                Value="0" />
 
-            <Setter Target="Artwork.VerticalAlignment"
-                    Value="Bottom" />
-            <Setter Target="ContentPanel.VerticalAlignment"
-                    Value="Center" />
-            <Setter Target="ButtonPanel.VerticalAlignment"
-                    Value="Center" />
+                        <Setter Target="Artwork.VerticalAlignment"
+                                Value="Bottom" />
+                        <Setter Target="ContentPanel.VerticalAlignment"
+                                Value="Center" />
+                        <Setter Target="ButtonPanel.VerticalAlignment"
+                                Value="Center" />
 
-            <Setter Target="Title.HorizontalAlignment"
-                    Value="Center" />
-            <Setter Target="Description.HorizontalAlignment"
-                    Value="Center" />
-            <Setter Target="Addtional.HorizontalAlignment"
-                    Value="Center" />
-            <Setter Target="ButtonPanel.HorizontalAlignment"
-                    Value="Center" />
-          </VisualState.Setters>
-        </VisualState>
+                        <Setter Target="Title.HorizontalAlignment"
+                                Value="Center" />
+                        <Setter Target="Description.HorizontalAlignment"
+                                Value="Center" />
+                        <Setter Target="Addtional.HorizontalAlignment"
+                                Value="Center" />
+                        <Setter Target="ButtonPanel.HorizontalAlignment"
+                                Value="Center" />
+                    </VisualState.Setters>
+                </VisualState>
 
-        <VisualState x:Name="TallFull">
-          <VisualState.StateTriggers>
-            <AdaptiveTrigger MinWindowHeight="320" />
-          </VisualState.StateTriggers>
-          <VisualState.Setters>
-            <Setter Target="Artwork.Visibility"
-                    Value="Visible" />
-            <Setter Target="Description.Visibility"
-                    Value="Visible" />
-            <Setter Target="Addtional.Visibility"
-                    Value="Visible" />
-            <Setter Target="Title.FontSize"
-                    Value="20" />
+                <VisualState x:Name="TallFull">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowHeight="320" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Artwork.Visibility"
+                                Value="Visible" />
+                        <Setter Target="Description.Visibility"
+                                Value="Visible" />
+                        <Setter Target="Addtional.Visibility"
+                                Value="Visible" />
+                        <Setter Target="Title.FontSize"
+                                Value="20" />
 
-            <Setter Target="Artwork.(Grid.Row)"
-                    Value="0" />
-            <Setter Target="Artwork.(Grid.RowSpan)"
-                    Value="1" />
-            <Setter Target="Artwork.(Grid.ColumnSpan)"
-                    Value="2" />
+                        <Setter Target="Artwork.(Grid.Row)"
+                                Value="0" />
+                        <Setter Target="Artwork.(Grid.RowSpan)"
+                                Value="1" />
+                        <Setter Target="Artwork.(Grid.ColumnSpan)"
+                                Value="2" />
 
-            <Setter Target="ButtonPanel.(Grid.ColumnSpan)"
-                    Value="2" />
-            <Setter Target="ContentPanel.(Grid.ColumnSpan)"
-                    Value="2" />
+                        <Setter Target="ButtonPanel.(Grid.ColumnSpan)"
+                                Value="2" />
+                        <Setter Target="ContentPanel.(Grid.ColumnSpan)"
+                                Value="2" />
 
-            <Setter Target="ButtonPanel.(Grid.Column)"
-                    Value="0" />
-            <Setter Target="ContentPanel.(Grid.Column)"
-                    Value="0" />
+                        <Setter Target="ButtonPanel.(Grid.Column)"
+                                Value="0" />
+                        <Setter Target="ContentPanel.(Grid.Column)"
+                                Value="0" />
 
-            <Setter Target="Artwork.VerticalAlignment"
-                    Value="Bottom" />
-            <Setter Target="ContentPanel.VerticalAlignment"
-                    Value="Center" />
-            <Setter Target="ButtonPanel.VerticalAlignment"
-                    Value="Center" />
+                        <Setter Target="Artwork.VerticalAlignment"
+                                Value="Bottom" />
+                        <Setter Target="ContentPanel.VerticalAlignment"
+                                Value="Center" />
+                        <Setter Target="ButtonPanel.VerticalAlignment"
+                                Value="Center" />
 
-            <Setter Target="Title.HorizontalAlignment"
-                    Value="Center" />
-            <Setter Target="Description.HorizontalAlignment"
-                    Value="Center" />
-            <Setter Target="Addtional.HorizontalAlignment"
-                    Value="Center" />
-            <Setter Target="ButtonPanel.HorizontalAlignment"
-                    Value="Center" />
-          </VisualState.Setters>
-        </VisualState>
-      </VisualStateGroup>
-    </VisualStateManager.VisualStateGroups>
-    <Grid.RowDefinitions>
-      <RowDefinition x:Name="RowOne"
-                     MinHeight="100"
-                     Height="*" />
-      <RowDefinition x:Name="RowTwo"
-                     Height="auto" />
-      <RowDefinition x:Name="RowThree"
-                     Height="auto" />
-    </Grid.RowDefinitions>
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="auto" />
-      <ColumnDefinition Width="*" />
-    </Grid.ColumnDefinitions>
+                        <Setter Target="Title.HorizontalAlignment"
+                                Value="Center" />
+                        <Setter Target="Description.HorizontalAlignment"
+                                Value="Center" />
+                        <Setter Target="Addtional.HorizontalAlignment"
+                                Value="Center" />
+                        <Setter Target="ButtonPanel.HorizontalAlignment"
+                                Value="Center" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+        <Grid.RowDefinitions>
+            <RowDefinition x:Name="RowOne"
+                           MinHeight="100"
+                           Height="*" />
+            <RowDefinition x:Name="RowTwo"
+                           Height="auto" />
+            <RowDefinition x:Name="RowThree"
+                           Height="auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
 
-    <Grid x:Name="ArtworkBG"
-          HorizontalAlignment="Stretch"
-          VerticalAlignment="Stretch"
-          Grid.ColumnSpan="2"
-          Grid.RowSpan="3"
-          Opacity="0.5">
-      <Grid.Background>
-        <ImageBrush AlignmentX="Center"
-                    AlignmentY="Center"
-                    Stretch="UniformToFill"
-                    ImageSource="{x:Bind Context.CurrentArtwork, Mode=OneWay, TargetNullValue=ms-appx:///Assets/Images/now_placeholder.png}" />
-      </Grid.Background>
+        <Grid x:Name="ArtworkBG"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch"
+              Grid.ColumnSpan="2"
+              Grid.RowSpan="3"
+              Opacity="0.5">
+            <Grid.Background>
+                <ImageBrush AlignmentX="Center"
+                            AlignmentY="Center"
+                            Stretch="UniformToFill"
+                            ImageSource="{x:Bind Context.CurrentArtwork, Mode=OneWay, TargetNullValue=ms-appx:///Assets/Images/now_placeholder.png}" />
+            </Grid.Background>
+        </Grid>
+
+        <Grid x:Name="ArtworkBGBlur"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch"
+              Grid.ColumnSpan="2"
+              Grid.RowSpan="3"
+              Loaded="ArtworkBGBlur_Loaded">
+            <interactivity:Interaction.Behaviors>
+                <behaviors:Blur Value="32"
+                                Duration="0"
+                                AutomaticallyStart="True" />
+            </interactivity:Interaction.Behaviors>
+        </Grid>
+
+        <toolkit:ImageEx Style="{ThemeResource QuickLoadImageEx}"
+                         x:Name="Artwork"
+                         Stretch="Uniform"
+                         Grid.RowSpan="3"
+                         HorizontalAlignment="Stretch"
+                         VerticalAlignment="Stretch"
+                         PlaceholderStretch="Uniform"
+                         PlaceholderSource="/Assets/Images/placeholder_b.png"
+                         Margin="16"
+                         Source="{x:Bind Context.CurrentArtwork, Mode=OneWay}" />
+
+        <StackPanel x:Name="ContentPanel"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Margin="0,0,0,8"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Bottom">
+            <TextBlock x:Name="Title"
+                       FontWeight="Bold"
+                       Text="{x:Bind Context.Song.Title, Mode=OneWay}"
+                       Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
+                       Style="{ThemeResource SubtitleTextBlockStyle}"
+                       MaxLines="2"
+                       TextWrapping="WrapWholeWords"
+                       TextTrimming="CharacterEllipsis"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center" />
+            <TextBlock x:Name="Description"
+                       Visibility="Collapsed"
+                       Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
+                       Text="{x:Bind Context.Song.Album,Mode=OneWay}"
+                       Style="{ThemeResource BodyTextBlockStyle}"
+                       Margin="0,4"
+                       MaxLines="1"
+                       TextWrapping="NoWrap"
+                       TextTrimming="CharacterEllipsis"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center" />
+            <TextBlock x:Name="Addtional"
+                       Visibility="Collapsed"
+                       Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
+                       Text="{x:Bind Context.Song.GetFormattedArtists(),Mode=OneWay}"
+                       Style="{ThemeResource BodyTextBlockStyle}"
+                       MaxLines="1"
+                       TextWrapping="NoWrap"
+                       TextTrimming="CharacterEllipsis"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center" />
+        </StackPanel>
+        <ScrollViewer x:Name="ButtonPanel"
+                      Margin="0,8,0,8"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Top"
+                      Grid.Column="1"
+                      Grid.Row="2"
+                      VerticalScrollMode="Disabled"
+                      VerticalScrollBarVisibility="Disabled"
+                      HorizontalScrollMode="Auto"
+                      HorizontalScrollBarVisibility="Auto">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Foreground="{ThemeResource SystemControlForegroundAltHighBrush}"
+                           x:Name="PlayListFull"
+                           Text="{x:Bind Context.NowListPreview,Mode=OneWay}"
+                           Style="{ThemeResource BodyTextBlockStyle}"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center" />
+                <Button x:Uid="Previous"
+                        x:Name="Previous"
+                        Style="{ThemeResource RevealRoundButton}"
+                        Command="{x:Bind Context.GoPrevious}"
+                        ToolTipService.ToolTip="Previous"
+                        Width="48"
+                        Height="48"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Stretch">
+                    <Button.Content>
+                        <SymbolIcon Symbol="Previous" />
+                    </Button.Content>
+                </Button>
+                <Button Style="{ThemeResource RevealRoundButton}"
+                        Command="{x:Bind Context.PlayPause}"
+                        ToolTipService.ToolTip="{x:Bind Context.NullableBoolToString(Context.IsPlaying), Mode=OneWay}"
+                        Width="48"
+                        Height="48"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Stretch">
+                    <Button.Content>
+                        <SymbolIcon Symbol="{x:Bind Context.NullableBoolToSymbol(Context.IsPlaying), Mode=OneWay}" />
+                    </Button.Content>
+                </Button>
+                <Button x:Uid="Next"
+                        Style="{ThemeResource RevealRoundButton}"
+                        Command="{x:Bind Context.GoNext}"
+                        ToolTipService.ToolTip="Next"
+                        Width="48"
+                        Height="48"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Stretch">
+                    <Button.Content>
+                        <SymbolIcon Symbol="Next" />
+                    </Button.Content>
+                </Button>
+
+                <Button x:Uid="GoBack"
+                        Style="{ThemeResource RevealRoundButton}"
+                        Command="{x:Bind Context.ReturnNormal}"
+                        ToolTipService.ToolTip="Go Back"
+                        Width="48"
+                        Height="48"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Stretch">
+                    <Button.Content>
+                        <FontIcon FontFamily="Segoe MDL2 Assets"
+                                  Glyph="&#xE2B3;" />
+                    </Button.Content>
+                </Button>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
-
-    <Grid x:Name="ArtworkBGBlur"
-          HorizontalAlignment="Stretch"
-          VerticalAlignment="Stretch"
-          Grid.ColumnSpan="2"
-          Grid.RowSpan="3"
-          Loaded="ArtworkBGBlur_Loaded">
-      <interactivity:Interaction.Behaviors>
-        <behaviors:Blur Value="32"
-                        Duration="0"
-                        AutomaticallyStart="True" />
-      </interactivity:Interaction.Behaviors>
-    </Grid>
-
-    <toolkit:ImageEx Style="{ThemeResource QuickLoadImageEx}"
-                     x:Name="Artwork"
-                     Stretch="Uniform"
-                     Grid.RowSpan="3"
-                     HorizontalAlignment="Stretch"
-                     VerticalAlignment="Stretch"
-                     PlaceholderStretch="Uniform"
-                     PlaceholderSource="/Assets/Images/placeholder_b.png"
-                     Margin="16"
-                     Source="{x:Bind Context.CurrentArtwork, Mode=OneWay}" />
-
-    <StackPanel x:Name="ContentPanel"
-                Grid.Row="1"
-                Grid.Column="1"
-                Margin="0,0,0,8"
-                HorizontalAlignment="Stretch"
-                VerticalAlignment="Bottom">
-      <TextBlock x:Name="Title"
-                 FontWeight="Bold"
-                 Text="{x:Bind Context.Song.Title, Mode=OneWay}"
-                 Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
-                 Style="{ThemeResource SubtitleTextBlockStyle}"
-                 MaxLines="2"
-                 TextWrapping="WrapWholeWords"
-                 TextTrimming="CharacterEllipsis"
-                 HorizontalAlignment="Center"
-                 VerticalAlignment="Center" />
-      <TextBlock x:Name="Description"
-                 Visibility="Collapsed"
-                 Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
-                 Text="{x:Bind Context.Song.Album,Mode=OneWay}"
-                 Style="{ThemeResource BodyTextBlockStyle}"
-                 Margin="0,4"
-                 MaxLines="1"
-                 TextWrapping="NoWrap"
-                 TextTrimming="CharacterEllipsis"
-                 HorizontalAlignment="Center"
-                 VerticalAlignment="Center" />
-      <TextBlock x:Name="Addtional"
-                 Visibility="Collapsed"
-                 Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
-                 Text="{x:Bind Context.Song.GetFormattedArtists(),Mode=OneWay}"
-                 Style="{ThemeResource BodyTextBlockStyle}"
-                 MaxLines="1"
-                 TextWrapping="NoWrap"
-                 TextTrimming="CharacterEllipsis"
-                 HorizontalAlignment="Center"
-                 VerticalAlignment="Center" />
-    </StackPanel>
-    <ScrollViewer x:Name="ButtonPanel"
-                  Margin="0,8,0,8"
-                  HorizontalAlignment="Center"
-                  VerticalAlignment="Top"
-                  Grid.Column="1"
-                  Grid.Row="2"
-                  VerticalScrollMode="Disabled"
-                  VerticalScrollBarVisibility="Disabled"
-                  HorizontalScrollMode="Auto"
-                  HorizontalScrollBarVisibility="Auto">
-      <StackPanel Orientation="Horizontal">
-        <TextBlock Foreground="{ThemeResource SystemControlForegroundAltHighBrush}"
-                   x:Name="PlayListFull"
-                   Text="{x:Bind Context.NowListPreview,Mode=OneWay}"
-                   Style="{ThemeResource BodyTextBlockStyle}"
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center" />
-        <Button x:Uid="Previous"
-                x:Name="Previous"
-                Style="{ThemeResource RevealRoundButton}"
-                Command="{x:Bind Context.GoPrevious}"
-                ToolTipService.ToolTip="Previous"
-                Width="48"
-                Height="48"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Stretch">
-          <Button.Content>
-            <SymbolIcon Symbol="Previous" />
-          </Button.Content>
-        </Button>
-        <Button Style="{ThemeResource RevealRoundButton}"
-                Command="{x:Bind Context.PlayPause}"
-                ToolTipService.ToolTip="{x:Bind Context.NullableBoolToString(Context.IsPlaying), Mode=OneWay}"
-                Width="48"
-                Height="48"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Stretch">
-          <Button.Content>
-            <SymbolIcon Symbol="{x:Bind Context.NullableBoolToSymbol(Context.IsPlaying), Mode=OneWay}" />
-          </Button.Content>
-        </Button>
-        <Button x:Uid="Next"
-                Style="{ThemeResource RevealRoundButton}"
-                Command="{x:Bind Context.GoNext}"
-                ToolTipService.ToolTip="Next"
-                Width="48"
-                Height="48"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Stretch">
-          <Button.Content>
-            <SymbolIcon Symbol="Next" />
-          </Button.Content>
-        </Button>
-
-        <Button x:Uid="GoBack"
-                Style="{ThemeResource RevealRoundButton}"
-                Command="{x:Bind Context.ReturnNormal}"
-                ToolTipService.ToolTip="Go Back"
-                Width="48"
-                Height="48"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Stretch">
-          <Button.Content>
-            <FontIcon FontFamily="Segoe MDL2 Assets"
-                      Glyph="&#xE2B3;" />
-          </Button.Content>
-        </Button>
-      </StackPanel>
-    </ScrollViewer>
-  </Grid>
 </Page>

--- a/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml
+++ b/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml
@@ -311,69 +311,74 @@ Licensed under the MIT License. See LICENSE in the project root for license info
                  HorizontalAlignment="Center"
                  VerticalAlignment="Center" />
     </StackPanel>
-    <StackPanel x:Name="ButtonPanel"
-                Orientation="Horizontal"
-                Margin="0,8,0,8"
+    <ScrollViewer x:Name="ButtonPanel"
+                  Margin="0,8,0,8"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Top"
+                  Grid.Column="1"
+                  Grid.Row="2"
+                  VerticalScrollMode="Disabled"
+                  VerticalScrollBarVisibility="Disabled"
+                  HorizontalScrollMode="Auto"
+                  HorizontalScrollBarVisibility="Auto">
+      <StackPanel Orientation="Horizontal">
+        <TextBlock Foreground="{ThemeResource SystemControlForegroundAltHighBrush}"
+                   x:Name="PlayListFull"
+                   Text="{x:Bind Context.NowListPreview,Mode=OneWay}"
+                   Style="{ThemeResource BodyTextBlockStyle}"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center" />
+        <Button x:Uid="Previous"
+                x:Name="Previous"
+                Style="{ThemeResource RevealRoundButton}"
+                Command="{x:Bind Context.GoPrevious}"
+                ToolTipService.ToolTip="Previous"
+                Width="48"
+                Height="48"
                 HorizontalAlignment="Center"
-                VerticalAlignment="Top"
-                Grid.Column="1"
-                Grid.Row="2">
-      <TextBlock Foreground="{ThemeResource SystemControlForegroundAltHighBrush}"
-                 x:Name="PlayListFull"
-                 Text="{x:Bind Context.NowListPreview,Mode=OneWay}"
-                 Style="{ThemeResource BodyTextBlockStyle}"
-                 HorizontalAlignment="Center"
-                 VerticalAlignment="Center" />
-      <Button x:Uid="Previous"
-              x:Name="Previous"
-              Style="{ThemeResource RevealRoundButton}"
-              Command="{x:Bind Context.GoPrevious}"
-              ToolTipService.ToolTip="Previous"
-              Width="48"
-              Height="48"
-              HorizontalAlignment="Center"
-              VerticalAlignment="Stretch">
-        <Button.Content>
-          <SymbolIcon Symbol="Previous" />
-        </Button.Content>
-      </Button>
-      <Button Style="{ThemeResource RevealRoundButton}"
-              Command="{x:Bind Context.PlayPause}"
-              ToolTipService.ToolTip="{x:Bind Context.NullableBoolToString(Context.IsPlaying), Mode=OneWay}"
-              Width="48"
-              Height="48"
-              HorizontalAlignment="Center"
-              VerticalAlignment="Stretch">
-        <Button.Content>
-          <SymbolIcon Symbol="{x:Bind Context.NullableBoolToSymbol(Context.IsPlaying), Mode=OneWay}" />
-        </Button.Content>
-      </Button>
-      <Button x:Uid="Next"
-              Style="{ThemeResource RevealRoundButton}"
-              Command="{x:Bind Context.GoNext}"
-              ToolTipService.ToolTip="Next"
-              Width="48"
-              Height="48"
-              HorizontalAlignment="Center"
-              VerticalAlignment="Stretch">
-        <Button.Content>
-          <SymbolIcon Symbol="Next" />
-        </Button.Content>
-      </Button>
+                VerticalAlignment="Stretch">
+          <Button.Content>
+            <SymbolIcon Symbol="Previous" />
+          </Button.Content>
+        </Button>
+        <Button Style="{ThemeResource RevealRoundButton}"
+                Command="{x:Bind Context.PlayPause}"
+                ToolTipService.ToolTip="{x:Bind Context.NullableBoolToString(Context.IsPlaying), Mode=OneWay}"
+                Width="48"
+                Height="48"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Stretch">
+          <Button.Content>
+            <SymbolIcon Symbol="{x:Bind Context.NullableBoolToSymbol(Context.IsPlaying), Mode=OneWay}" />
+          </Button.Content>
+        </Button>
+        <Button x:Uid="Next"
+                Style="{ThemeResource RevealRoundButton}"
+                Command="{x:Bind Context.GoNext}"
+                ToolTipService.ToolTip="Next"
+                Width="48"
+                Height="48"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Stretch">
+          <Button.Content>
+            <SymbolIcon Symbol="Next" />
+          </Button.Content>
+        </Button>
 
-      <Button x:Uid="GoBack"
-              Style="{ThemeResource RevealRoundButton}"
-              Command="{x:Bind Context.ReturnNormal}"
-              ToolTipService.ToolTip="Go Back"
-              Width="48"
-              Height="48"
-              HorizontalAlignment="Center"
-              VerticalAlignment="Stretch">
-        <Button.Content>
-          <FontIcon FontFamily="Segoe MDL2 Assets"
-                    Glyph="&#xE2B3;" />
-        </Button.Content>
-      </Button>
-    </StackPanel>
+        <Button x:Uid="GoBack"
+                Style="{ThemeResource RevealRoundButton}"
+                Command="{x:Bind Context.ReturnNormal}"
+                ToolTipService.ToolTip="Go Back"
+                Width="48"
+                Height="48"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Stretch">
+          <Button.Content>
+            <FontIcon FontFamily="Segoe MDL2 Assets"
+                      Glyph="&#xE2B3;" />
+          </Button.Content>
+        </Button>
+      </StackPanel>
+    </ScrollViewer>
   </Grid>
 </Page>

--- a/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml
+++ b/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml
@@ -3,234 +3,377 @@ Copyright (c) Aurora Studio. All rights reserved.
 
 Licensed under the MIT License. See LICENSE in the project root for license information.
 -->
-<Page
-    x:Class="Aurora.Music.Controls.CompactOverlayPanel"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Aurora.Music.Controls"
-    xmlns:model="using:Aurora.Music.Core.Models"
-    xmlns:vm="using:Aurora.Music.ViewModels"
-    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Animations.Behaviors"
-    Unloaded="Page_Unloaded"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+<Page x:Class="Aurora.Music.Controls.CompactOverlayPanel"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Aurora.Music.Controls"
+      xmlns:model="using:Aurora.Music.Core.Models"
+      xmlns:vm="using:Aurora.Music.ViewModels"
+      xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+      xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Animations.Behaviors"
+      Unloaded="Page_Unloaded"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
 
-    <Page.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../Themes/Styles.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Light" Source="../Themes/Light.xaml"/>
-                <ResourceDictionary x:Key="Dark" Source="../Themes/Dark.xaml"/>
-            </ResourceDictionary.ThemeDictionaries>
-        </ResourceDictionary>
-    </Page.Resources>
+  <Page.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="../Themes/Styles.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+      <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light"
+                            Source="../Themes/Light.xaml" />
+        <ResourceDictionary x:Key="Dark"
+                            Source="../Themes/Dark.xaml" />
+      </ResourceDictionary.ThemeDictionaries>
+    </ResourceDictionary>
+  </Page.Resources>
 
+  <Page.DataContext>
+    <vm:NowPlayingPageViewModel x:Name="Context" />
+  </Page.DataContext>
 
-    <Page.DataContext>
-        <vm:NowPlayingPageViewModel x:Name="Context"/>
-    </Page.DataContext>
+  <Grid x:Name="Root"
+        Background="{ThemeResource SystemControlBackgroundBaseHighBrush}">
+    <VisualStateManager.VisualStateGroups>
+      <VisualStateGroup>
+        <VisualState x:Name="Narrow">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowWidth="0" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Previous.Visibility"
+                    Value="Collapsed" />
+            <Setter Target="PlayListFull.Visibility"
+                    Value="Collapsed" />
+            <Setter Target="Artwork.Visibility"
+                    Value="Collapsed" />
+            <Setter Target="ContentPanel.HorizontalAlignment"
+                    Value="Center" />
+            <Setter Target="ButtonPanel.HorizontalAlignment"
+                    Value="Center" />
+          </VisualState.Setters>
+        </VisualState>
 
-    <Grid x:Name="Root" Background="{ThemeResource SystemControlBackgroundBaseHighBrush}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup>
-                <VisualState x:Name="Narrow">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="0"/>
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="Previous.Visibility" Value="Collapsed"/>
-                        <Setter Target="PlayListFull.Visibility" Value="Collapsed"/>
-                        <Setter Target="Artwork.Visibility" Value="Collapsed"/>
-                        <Setter Target="ContentPanel.HorizontalAlignment" Value="Center"/>
-                        <Setter Target="ButtonPanel.HorizontalAlignment" Value="Center"/>
-                    </VisualState.Setters>
-                </VisualState>
+        <VisualState x:Name="Medium">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowWidth="240" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Previous.Visibility"
+                    Value="Collapsed" />
+            <Setter Target="PlayListFull.Visibility"
+                    Value="Visible" />
+            <Setter Target="Artwork.MaxWidth"
+                    Value="200" />
+            <Setter Target="Artwork.Visibility"
+                    Value="Visible" />
+          </VisualState.Setters>
+        </VisualState>
 
-                <VisualState x:Name="Medium">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="240"/>
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="Previous.Visibility" Value="Collapsed"/>
-                        <Setter Target="PlayListFull.Visibility" Value="Visible"/>
-                        <Setter Target="Artwork.MaxWidth" Value="200"/>
-                        <Setter Target="Artwork.Visibility" Value="Visible"/>
-                    </VisualState.Setters>
-                </VisualState>
+        <VisualState x:Name="Full">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowWidth="320" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Previous.Visibility"
+                    Value="Visible" />
+            <Setter Target="PlayListFull.Visibility"
+                    Value="Visible" />
+            <Setter Target="Artwork.MaxWidth"
+                    Value="250" />
+            <Setter Target="PlayListFull.Visibility"
+                    Value="Visible" />
+            <Setter Target="Artwork.Visibility"
+                    Value="Visible" />
+          </VisualState.Setters>
+        </VisualState>
+      </VisualStateGroup>
+      <VisualStateGroup>
+        <VisualState x:Name="Short">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowHeight="0" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Description.Visibility"
+                    Value="Collapsed" />
+            <Setter Target="Addtional.Visibility"
+                    Value="Collapsed" />
+            <Setter Target="Title.HorizontalAlignment"
+                    Value="Left" />
+            <Setter Target="ContentPanel.HorizontalAlignment"
+                    Value="Left" />
+            <Setter Target="ButtonPanel.HorizontalAlignment"
+                    Value="Left" />
+            <Setter Target="RowOne.Height"
+                    Value="0" />
+            <Setter Target="RowOne.MinHeight"
+                    Value="0" />
+            <Setter Target="RowTwo.Height"
+                    Value="*" />
+            <Setter Target="RowThree.Height"
+                    Value="*" />
+            <Setter Target="ContentPanel.VerticalAlignment"
+                    Value="Center" />
+            <Setter Target="ButtonPanel.VerticalAlignment"
+                    Value="Center" />
+          </VisualState.Setters>
+        </VisualState>
 
-                <VisualState x:Name="Full">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="320"/>
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="Previous.Visibility" Value="Visible"/>
-                        <Setter Target="PlayListFull.Visibility" Value="Visible"/>
-                        <Setter Target="Artwork.MaxWidth" Value="250"/>
-                        <Setter Target="PlayListFull.Visibility" Value="Visible"/>
-                        <Setter Target="Artwork.Visibility" Value="Visible"/>
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-            <VisualStateGroup>
-                <VisualState x:Name="Short">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowHeight="0"/>
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="Description.Visibility" Value="Collapsed"/>
-                        <Setter Target="Addtional.Visibility" Value="Collapsed"/>
-                        <Setter Target="Title.HorizontalAlignment" Value="Left"/>
-                        <Setter Target="ContentPanel.HorizontalAlignment" Value="Left"/>
-                        <Setter Target="ButtonPanel.HorizontalAlignment" Value="Left"/>
-                        <Setter Target="RowOne.Height" Value="0"/>
-                        <Setter Target="RowOne.MinHeight" Value="0"/>
-                        <Setter Target="RowTwo.Height" Value="*"/>
-                        <Setter Target="RowThree.Height" Value="*"/>
-                        <Setter Target="ContentPanel.VerticalAlignment" Value="Center"/>
-                        <Setter Target="ButtonPanel.VerticalAlignment" Value="Center"/>
-                    </VisualState.Setters>
-                </VisualState>
+        <VisualState x:Name="Tall">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowHeight="250" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Artwork.Visibility"
+                    Value="Visible" />
+            <Setter Target="Description.Visibility"
+                    Value="Collapsed" />
+            <Setter Target="Addtional.Visibility"
+                    Value="Collapsed" />
+            <Setter Target="Title.FontSize"
+                    Value="20" />
 
-                <VisualState x:Name="Tall">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowHeight="250"/>
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="Artwork.Visibility" Value="Visible"/>
-                        <Setter Target="Description.Visibility" Value="Collapsed"/>
-                        <Setter Target="Addtional.Visibility" Value="Collapsed"/>
-                        <Setter Target="Title.FontSize" Value="20"/>
+            <Setter Target="Artwork.(Grid.Row)"
+                    Value="0" />
+            <Setter Target="Artwork.(Grid.RowSpan)"
+                    Value="1" />
+            <Setter Target="Artwork.(Grid.ColumnSpan)"
+                    Value="2" />
 
-                        <Setter Target="Artwork.(Grid.Row)" Value="0"/>
-                        <Setter Target="Artwork.(Grid.RowSpan)" Value="1"/>
-                        <Setter Target="Artwork.(Grid.ColumnSpan)" Value="2"/>
+            <Setter Target="ButtonPanel.(Grid.ColumnSpan)"
+                    Value="2" />
+            <Setter Target="ContentPanel.(Grid.ColumnSpan)"
+                    Value="2" />
 
-                        <Setter Target="ButtonPanel.(Grid.ColumnSpan)" Value="2"/>
-                        <Setter Target="ContentPanel.(Grid.ColumnSpan)" Value="2"/>
+            <Setter Target="ButtonPanel.(Grid.Column)"
+                    Value="0" />
+            <Setter Target="ContentPanel.(Grid.Column)"
+                    Value="0" />
 
-                        <Setter Target="ButtonPanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="ContentPanel.(Grid.Column)" Value="0"/>
+            <Setter Target="Artwork.VerticalAlignment"
+                    Value="Bottom" />
+            <Setter Target="ContentPanel.VerticalAlignment"
+                    Value="Center" />
+            <Setter Target="ButtonPanel.VerticalAlignment"
+                    Value="Center" />
 
-                        <Setter Target="Artwork.VerticalAlignment" Value="Bottom"/>
-                        <Setter Target="ContentPanel.VerticalAlignment" Value="Center"/>
-                        <Setter Target="ButtonPanel.VerticalAlignment" Value="Center"/>
+            <Setter Target="Title.HorizontalAlignment"
+                    Value="Center" />
+            <Setter Target="Description.HorizontalAlignment"
+                    Value="Center" />
+            <Setter Target="Addtional.HorizontalAlignment"
+                    Value="Center" />
+            <Setter Target="ButtonPanel.HorizontalAlignment"
+                    Value="Center" />
+          </VisualState.Setters>
+        </VisualState>
 
-                        <Setter Target="Title.HorizontalAlignment" Value="Center"/>
-                        <Setter Target="Description.HorizontalAlignment" Value="Center"/>
-                        <Setter Target="Addtional.HorizontalAlignment" Value="Center"/>
-                        <Setter Target="ButtonPanel.HorizontalAlignment" Value="Center"/>
-                    </VisualState.Setters>
-                </VisualState>
+        <VisualState x:Name="TallFull">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowHeight="320" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Artwork.Visibility"
+                    Value="Visible" />
+            <Setter Target="Description.Visibility"
+                    Value="Visible" />
+            <Setter Target="Addtional.Visibility"
+                    Value="Visible" />
+            <Setter Target="Title.FontSize"
+                    Value="20" />
 
-                <VisualState x:Name="TallFull">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowHeight="320"/>
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="Artwork.Visibility" Value="Visible"/>
-                        <Setter Target="Description.Visibility" Value="Visible"/>
-                        <Setter Target="Addtional.Visibility" Value="Visible"/>
-                        <Setter Target="Title.FontSize" Value="20"/>
+            <Setter Target="Artwork.(Grid.Row)"
+                    Value="0" />
+            <Setter Target="Artwork.(Grid.RowSpan)"
+                    Value="1" />
+            <Setter Target="Artwork.(Grid.ColumnSpan)"
+                    Value="2" />
 
-                        <Setter Target="Artwork.(Grid.Row)" Value="0"/>
-                        <Setter Target="Artwork.(Grid.RowSpan)" Value="1"/>
-                        <Setter Target="Artwork.(Grid.ColumnSpan)" Value="2"/>
+            <Setter Target="ButtonPanel.(Grid.ColumnSpan)"
+                    Value="2" />
+            <Setter Target="ContentPanel.(Grid.ColumnSpan)"
+                    Value="2" />
 
-                        <Setter Target="ButtonPanel.(Grid.ColumnSpan)" Value="2"/>
-                        <Setter Target="ContentPanel.(Grid.ColumnSpan)" Value="2"/>
+            <Setter Target="ButtonPanel.(Grid.Column)"
+                    Value="0" />
+            <Setter Target="ContentPanel.(Grid.Column)"
+                    Value="0" />
 
-                        <Setter Target="ButtonPanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="ContentPanel.(Grid.Column)" Value="0"/>
+            <Setter Target="Artwork.VerticalAlignment"
+                    Value="Bottom" />
+            <Setter Target="ContentPanel.VerticalAlignment"
+                    Value="Center" />
+            <Setter Target="ButtonPanel.VerticalAlignment"
+                    Value="Center" />
 
-                        <Setter Target="Artwork.VerticalAlignment" Value="Bottom"/>
-                        <Setter Target="ContentPanel.VerticalAlignment" Value="Center"/>
-                        <Setter Target="ButtonPanel.VerticalAlignment" Value="Center"/>
+            <Setter Target="Title.HorizontalAlignment"
+                    Value="Center" />
+            <Setter Target="Description.HorizontalAlignment"
+                    Value="Center" />
+            <Setter Target="Addtional.HorizontalAlignment"
+                    Value="Center" />
+            <Setter Target="ButtonPanel.HorizontalAlignment"
+                    Value="Center" />
+          </VisualState.Setters>
+        </VisualState>
+      </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
+    <Grid.RowDefinitions>
+      <RowDefinition x:Name="RowOne"
+                     MinHeight="100"
+                     Height="*" />
+      <RowDefinition x:Name="RowTwo"
+                     Height="auto" />
+      <RowDefinition x:Name="RowThree"
+                     Height="auto" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="auto" />
+      <ColumnDefinition Width="*" />
+    </Grid.ColumnDefinitions>
 
-                        <Setter Target="Title.HorizontalAlignment" Value="Center"/>
-                        <Setter Target="Description.HorizontalAlignment" Value="Center"/>
-                        <Setter Target="Addtional.HorizontalAlignment" Value="Center"/>
-                        <Setter Target="ButtonPanel.HorizontalAlignment" Value="Center"/>
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.RowDefinitions>
-            <RowDefinition x:Name="RowOne" MinHeight="100" Height="*"/>
-            <RowDefinition x:Name="RowTwo" Height="auto"/>
-            <RowDefinition x:Name="RowThree" Height="auto"/>
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="auto"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
-
-        <Grid x:Name="ArtworkBG" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="3" Opacity="0.5">
-            <Grid.Background>
-                <ImageBrush AlignmentX="Center" AlignmentY="Center" Stretch="UniformToFill" ImageSource="{x:Bind Context.CurrentArtwork, Mode=OneWay, TargetNullValue=ms-appx:///Assets/Images/now_placeholder.png}"/>
-            </Grid.Background>
-        </Grid>
-
-        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="3">
-            <interactivity:Interaction.Behaviors>
-                <behaviors:Blur Value="32" Duration="0" AutomaticallyStart="True"/>
-            </interactivity:Interaction.Behaviors>
-        </Grid>
-
-        <toolkit:ImageEx Style="{ThemeResource QuickLoadImageEx}" x:Name="Artwork" Stretch="Uniform" Grid.RowSpan="3"
-                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch" PlaceholderStretch="Uniform"
-                         PlaceholderSource="/Assets/Images/placeholder_b.png"
-                         Margin="16" Source="{x:Bind Context.CurrentArtwork, Mode=OneWay}"/>
-
-        <StackPanel x:Name="ContentPanel" Grid.Row="1" Grid.Column="1" Margin="0,0,0,8" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
-            <TextBlock x:Name="Title" FontWeight="Bold"
-                       Text="{x:Bind Context.Song.Title, Mode=OneWay}" 
-                       Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}" 
-                       Style="{ThemeResource SubtitleTextBlockStyle}" MaxLines="2" TextWrapping="WrapWholeWords" 
-                       TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            <TextBlock x:Name="Description" Visibility="Collapsed" 
-                       Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}" 
-                       Text="{x:Bind Context.Song.Album,Mode=OneWay}" Style="{ThemeResource BodyTextBlockStyle}" 
-                       Margin="0,4" MaxLines="1" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" 
-                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            <TextBlock x:Name="Addtional" Visibility="Collapsed" 
-                       Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}" 
-                       Text="{x:Bind Context.Song.GetFormattedArtists(),Mode=OneWay}" Style="{ThemeResource BodyTextBlockStyle}" 
-                       MaxLines="1" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-        </StackPanel>
-        <StackPanel x:Name="ButtonPanel" Orientation="Horizontal" Margin="0,8,0,8" HorizontalAlignment="Center" VerticalAlignment="Top" Grid.Column="1" Grid.Row="2">
-            <TextBlock Foreground="{ThemeResource SystemControlForegroundAltHighBrush}" x:Name="PlayListFull" Text="{x:Bind Context.NowListPreview,Mode=OneWay}" Style="{ThemeResource BodyTextBlockStyle}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            <Button x:Uid="Previous" x:Name="Previous" Style="{ThemeResource RevealRoundButton}" Command="{x:Bind Context.GoPrevious}" ToolTipService.ToolTip="Previous"
-                                Width="48" Height="48" HorizontalAlignment="Center" VerticalAlignment="Stretch">
-                <Button.Content>
-                    <SymbolIcon Symbol="Previous"/>
-                </Button.Content>
-            </Button>
-            <Button Style="{ThemeResource RevealRoundButton}" Command="{x:Bind Context.PlayPause}" ToolTipService.ToolTip="{x:Bind Context.NullableBoolToString(Context.IsPlaying), Mode=OneWay}"
-                                Width="48" Height="48" HorizontalAlignment="Center" VerticalAlignment="Stretch">
-                <Button.Content>
-                    <SymbolIcon Symbol="{x:Bind Context.NullableBoolToSymbol(Context.IsPlaying), Mode=OneWay}"/>
-                </Button.Content>
-            </Button>
-            <Button x:Uid="Next" Style="{ThemeResource RevealRoundButton}" Command="{x:Bind Context.GoNext}" ToolTipService.ToolTip="Next"
-                                Width="48" Height="48" HorizontalAlignment="Center" VerticalAlignment="Stretch">
-                <Button.Content>
-                    <SymbolIcon Symbol="Next"/>
-                </Button.Content>
-            </Button>
-
-            <Button x:Uid="GoBack" Style="{ThemeResource RevealRoundButton}" Command="{x:Bind Context.ReturnNormal}" ToolTipService.ToolTip="Go Back"
-                                Width="48" Height="48" HorizontalAlignment="Center" VerticalAlignment="Stretch">
-                <Button.Content>
-                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE2B3;" />
-                </Button.Content>
-            </Button>
-        </StackPanel>
-
-        <Grid Background="Transparent" Loaded="TitleBar_Loaded" Grid.ColumnSpan="2" HorizontalAlignment="Stretch" VerticalAlignment="Top" x:Name="TitleBar"/>
+    <Grid x:Name="ArtworkBG"
+          HorizontalAlignment="Stretch"
+          VerticalAlignment="Stretch"
+          Grid.ColumnSpan="2"
+          Grid.RowSpan="3"
+          Opacity="0.5">
+      <Grid.Background>
+        <ImageBrush AlignmentX="Center"
+                    AlignmentY="Center"
+                    Stretch="UniformToFill"
+                    ImageSource="{x:Bind Context.CurrentArtwork, Mode=OneWay, TargetNullValue=ms-appx:///Assets/Images/now_placeholder.png}" />
+      </Grid.Background>
     </Grid>
+
+    <Grid x:Name="ArtworkBGBlur"
+          HorizontalAlignment="Stretch"
+          VerticalAlignment="Stretch"
+          Grid.ColumnSpan="2"
+          Grid.RowSpan="3"
+          Loaded="ArtworkBGBlur_Loaded">
+      <interactivity:Interaction.Behaviors>
+        <behaviors:Blur Value="32"
+                        Duration="0"
+                        AutomaticallyStart="True" />
+      </interactivity:Interaction.Behaviors>
+    </Grid>
+
+    <toolkit:ImageEx Style="{ThemeResource QuickLoadImageEx}"
+                     x:Name="Artwork"
+                     Stretch="Uniform"
+                     Grid.RowSpan="3"
+                     HorizontalAlignment="Stretch"
+                     VerticalAlignment="Stretch"
+                     PlaceholderStretch="Uniform"
+                     PlaceholderSource="/Assets/Images/placeholder_b.png"
+                     Margin="16"
+                     Source="{x:Bind Context.CurrentArtwork, Mode=OneWay}" />
+
+    <StackPanel x:Name="ContentPanel"
+                Grid.Row="1"
+                Grid.Column="1"
+                Margin="0,0,0,8"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Bottom">
+      <TextBlock x:Name="Title"
+                 FontWeight="Bold"
+                 Text="{x:Bind Context.Song.Title, Mode=OneWay}"
+                 Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
+                 Style="{ThemeResource SubtitleTextBlockStyle}"
+                 MaxLines="2"
+                 TextWrapping="WrapWholeWords"
+                 TextTrimming="CharacterEllipsis"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center" />
+      <TextBlock x:Name="Description"
+                 Visibility="Collapsed"
+                 Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
+                 Text="{x:Bind Context.Song.Album,Mode=OneWay}"
+                 Style="{ThemeResource BodyTextBlockStyle}"
+                 Margin="0,4"
+                 MaxLines="1"
+                 TextWrapping="NoWrap"
+                 TextTrimming="CharacterEllipsis"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center" />
+      <TextBlock x:Name="Addtional"
+                 Visibility="Collapsed"
+                 Foreground="{x:Bind Context.AccentForeground(Context.IsAccentDark), Mode=OneWay}"
+                 Text="{x:Bind Context.Song.GetFormattedArtists(),Mode=OneWay}"
+                 Style="{ThemeResource BodyTextBlockStyle}"
+                 MaxLines="1"
+                 TextWrapping="NoWrap"
+                 TextTrimming="CharacterEllipsis"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center" />
+    </StackPanel>
+    <StackPanel x:Name="ButtonPanel"
+                Orientation="Horizontal"
+                Margin="0,8,0,8"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Grid.Column="1"
+                Grid.Row="2">
+      <TextBlock Foreground="{ThemeResource SystemControlForegroundAltHighBrush}"
+                 x:Name="PlayListFull"
+                 Text="{x:Bind Context.NowListPreview,Mode=OneWay}"
+                 Style="{ThemeResource BodyTextBlockStyle}"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center" />
+      <Button x:Uid="Previous"
+              x:Name="Previous"
+              Style="{ThemeResource RevealRoundButton}"
+              Command="{x:Bind Context.GoPrevious}"
+              ToolTipService.ToolTip="Previous"
+              Width="48"
+              Height="48"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Stretch">
+        <Button.Content>
+          <SymbolIcon Symbol="Previous" />
+        </Button.Content>
+      </Button>
+      <Button Style="{ThemeResource RevealRoundButton}"
+              Command="{x:Bind Context.PlayPause}"
+              ToolTipService.ToolTip="{x:Bind Context.NullableBoolToString(Context.IsPlaying), Mode=OneWay}"
+              Width="48"
+              Height="48"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Stretch">
+        <Button.Content>
+          <SymbolIcon Symbol="{x:Bind Context.NullableBoolToSymbol(Context.IsPlaying), Mode=OneWay}" />
+        </Button.Content>
+      </Button>
+      <Button x:Uid="Next"
+              Style="{ThemeResource RevealRoundButton}"
+              Command="{x:Bind Context.GoNext}"
+              ToolTipService.ToolTip="Next"
+              Width="48"
+              Height="48"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Stretch">
+        <Button.Content>
+          <SymbolIcon Symbol="Next" />
+        </Button.Content>
+      </Button>
+
+      <Button x:Uid="GoBack"
+              Style="{ThemeResource RevealRoundButton}"
+              Command="{x:Bind Context.ReturnNormal}"
+              ToolTipService.ToolTip="Go Back"
+              Width="48"
+              Height="48"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Stretch">
+        <Button.Content>
+          <FontIcon FontFamily="Segoe MDL2 Assets"
+                    Glyph="&#xE2B3;" />
+        </Button.Content>
+      </Button>
+    </StackPanel>
+  </Grid>
 </Page>

--- a/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml.cs
+++ b/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml.cs
@@ -49,38 +49,14 @@ namespace Aurora.Music.Controls
             Context.ReturnNormal.Execute();
         }
 
-        private void TitleBar_Loaded(object sender, RoutedEventArgs e)
-        {
-            var coreTitleBar = CoreApplication.GetCurrentView().TitleBar;
-            // Update title bar control size as needed to account for system size changes.
-            TitleBar.Height = coreTitleBar.Height;
-
-            coreTitleBar.LayoutMetricsChanged += CoreTitleBar_LayoutMetricsChanged;
-            coreTitleBar.IsVisibleChanged += CoreTitleBar_IsVisibleChanged;
-
-            Window.Current.SetTitleBar(TitleBar);
-        }
-
-        private void CoreTitleBar_IsVisibleChanged(CoreApplicationViewTitleBar sender, object args)
-        {
-            if (sender.IsVisible)
-            {
-                TitleBar.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                TitleBar.Visibility = Visibility.Collapsed;
-            }
-        }
-
-        private void CoreTitleBar_LayoutMetricsChanged(CoreApplicationViewTitleBar sender, object args)
-        {
-            TitleBar.Height = sender.Height;
-        }
-
         private void Page_Unloaded(object sender, RoutedEventArgs e)
         {
             SystemNavigationManager.GetForCurrentView().BackRequested -= CompactOverlayPanel_BackRequested;
+        }
+
+        private void ArtworkBGBlur_Loaded(object sender, RoutedEventArgs e)
+        {
+            Window.Current.SetTitleBar(ArtworkBGBlur);
         }
     }
 }

--- a/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml.cs
+++ b/Source/Aurora.Music/Controls/CompactOverlayPanel.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Aurora Studio. All rights reserved.
+// Copyright (c) Aurora Studio. All rights reserved.
 //
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using Aurora.Music.ViewModels;

--- a/Source/Aurora.Music/Controls/LyricView.xaml
+++ b/Source/Aurora.Music/Controls/LyricView.xaml
@@ -3,39 +3,84 @@ Copyright (c) Aurora Studio. All rights reserved.
 
 Licensed under the MIT License. See LICENSE in the project root for license information.
 -->
-<Page
-    x:Class="Aurora.Music.Controls.LyricView"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Aurora.Music.Controls"
-    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    Unloaded="Page_Unloaded"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+<Page x:Class="Aurora.Music.Controls.LyricView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Aurora.Music.Controls"
+      xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      Unloaded="Page_Unloaded"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
 
-    <Page.Resources>
-        <AcrylicBrush x:Key="ROOTBG" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0" FallbackColor="{ThemeResource SystemAltLowColor}" />
-    </Page.Resources>
+  <Page.Resources>
+    <AcrylicBrush x:Key="ROOTBG"
+                  BackgroundSource="HostBackdrop"
+                  TintColor="{ThemeResource SystemChromeAltHighColor}"
+                  TintOpacity="0"
+                  FallbackColor="{ThemeResource SystemAltLowColor}" />
+    <Style x:Key="LyricTextBlockStyle"
+           TargetType="TextBlock"
+           BasedOn="{StaticResource TitleTextBlockStyle}">
+      <Setter Property="TextWrapping"
+              Value="Wrap" />
+      <Setter Property="TextTrimming"
+              Value="CharacterEllipsis" />
+      <Setter Property="TextWrapping"
+              Value="NoWrap" />
+      <Setter Property="TextAlignment"
+              Value="Center" />
+      <Setter Property="HorizontalAlignment"
+              Value="Center" />
+      <Setter Property="VerticalAlignment"
+              Value="Center" />
+    </Style>
+    <Style x:Key="LyricDropShadowPanelStyle"
+           TargetType="toolkit:DropShadowPanel">
+      <Setter Property="Color"
+              Value="{ThemeResource SystemBaseHighColor}" />
+      <Setter Property="HorizontalAlignment"
+              Value="Center" />
+      <Setter Property="VerticalAlignment"
+              Value="Center" />
+      <Setter Property="BlurRadius"
+              Value="8" />
+      <Setter Property="OffsetX"
+              Value="0" />
+      <Setter Property="OffsetY"
+              Value="0" />
+      <Setter Property="OffsetZ"
+              Value="0" />
+    </Style>
+  </Page.Resources>
 
-    <Grid Background="{ThemeResource ROOTBG}" x:Name="Root">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+  <Grid Background="{ThemeResource ROOTBG}"
+        x:Name="Root">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
 
-        <toolkit:DropShadowPanel Opacity="0.33333" Color="White" HorizontalAlignment="Center" VerticalAlignment="Center" BlurRadius="8" OffsetX="0" OffsetY="0" Grid.Row="0">
-            <TextBlock Text="{x:Bind Lyric.GetPrevious(Lyric.CurrentIndex),Mode=OneWay}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" TextAlignment="Center" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ThemeResource TitleTextBlockStyle}"/>
-        </toolkit:DropShadowPanel>
+    <toolkit:DropShadowPanel Opacity="0.33333"
+                             Style="{StaticResource LyricDropShadowPanelStyle}"
+                             Grid.Row="0">
+      <TextBlock Text="{x:Bind Lyric.GetPrevious(Lyric.CurrentIndex),Mode=OneWay}"
+                 Style="{ThemeResource LyricTextBlockStyle}" />
+    </toolkit:DropShadowPanel>
 
-        <toolkit:DropShadowPanel Color="White" HorizontalAlignment="Center" VerticalAlignment="Center" BlurRadius="8" OffsetX="0" OffsetY="0" Grid.Row="1">
-            <TextBlock Text="{x:Bind Lyric.GetCurrent(Lyric.CurrentIndex),Mode=OneWay}" MaxLines="1" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" TextAlignment="Center" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ThemeResource TitleTextBlockStyle}"/>
-        </toolkit:DropShadowPanel>
+    <toolkit:DropShadowPanel Style="{StaticResource LyricDropShadowPanelStyle}"
+                             Grid.Row="1">
+      <TextBlock Text="{x:Bind Lyric.GetCurrent(Lyric.CurrentIndex),Mode=OneWay}"
+                 Style="{ThemeResource LyricTextBlockStyle}" />
+    </toolkit:DropShadowPanel>
 
-        <toolkit:DropShadowPanel Opacity="0.33333" Color="White" HorizontalAlignment="Center" VerticalAlignment="Center" BlurRadius="8" OffsetX="0" OffsetY="0" Grid.Row="2">
-            <TextBlock Text="{x:Bind Lyric.GetNext(Lyric.CurrentIndex),Mode=OneWay}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" TextAlignment="Center" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ThemeResource TitleTextBlockStyle}"/>
-        </toolkit:DropShadowPanel>
+    <toolkit:DropShadowPanel Opacity="0.33333"
+                             Style="{StaticResource LyricDropShadowPanelStyle}"
+                             Grid.Row="2">
+      <TextBlock Text="{x:Bind Lyric.GetNext(Lyric.CurrentIndex),Mode=OneWay}"
+                 Style="{ThemeResource LyricTextBlockStyle}" />
+    </toolkit:DropShadowPanel>
 
-    </Grid>
+  </Grid>
 </Page>

--- a/Source/Aurora.Music/Controls/LyricView.xaml
+++ b/Source/Aurora.Music/Controls/LyricView.xaml
@@ -13,74 +13,74 @@ Licensed under the MIT License. See LICENSE in the project root for license info
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
 
-  <Page.Resources>
-    <AcrylicBrush x:Key="ROOTBG"
-                  BackgroundSource="HostBackdrop"
-                  TintColor="{ThemeResource SystemChromeAltHighColor}"
-                  TintOpacity="0"
-                  FallbackColor="{ThemeResource SystemAltLowColor}" />
-    <Style x:Key="LyricTextBlockStyle"
-           TargetType="TextBlock"
-           BasedOn="{StaticResource TitleTextBlockStyle}">
-      <Setter Property="TextWrapping"
-              Value="Wrap" />
-      <Setter Property="TextTrimming"
-              Value="CharacterEllipsis" />
-      <Setter Property="TextWrapping"
-              Value="NoWrap" />
-      <Setter Property="TextAlignment"
-              Value="Center" />
-      <Setter Property="HorizontalAlignment"
-              Value="Center" />
-      <Setter Property="VerticalAlignment"
-              Value="Center" />
-    </Style>
-    <Style x:Key="LyricDropShadowPanelStyle"
-           TargetType="toolkit:DropShadowPanel">
-      <Setter Property="Color"
-              Value="{ThemeResource SystemBaseHighColor}" />
-      <Setter Property="HorizontalAlignment"
-              Value="Center" />
-      <Setter Property="VerticalAlignment"
-              Value="Center" />
-      <Setter Property="BlurRadius"
-              Value="8" />
-      <Setter Property="OffsetX"
-              Value="0" />
-      <Setter Property="OffsetY"
-              Value="0" />
-      <Setter Property="OffsetZ"
-              Value="0" />
-    </Style>
-  </Page.Resources>
+    <Page.Resources>
+        <AcrylicBrush x:Key="ROOTBG"
+                      BackgroundSource="HostBackdrop"
+                      TintColor="{ThemeResource SystemChromeAltHighColor}"
+                      TintOpacity="0"
+                      FallbackColor="{ThemeResource SystemAltLowColor}" />
+        <Style x:Key="LyricTextBlockStyle"
+               TargetType="TextBlock"
+               BasedOn="{StaticResource TitleTextBlockStyle}">
+            <Setter Property="TextWrapping"
+                    Value="Wrap" />
+            <Setter Property="TextTrimming"
+                    Value="CharacterEllipsis" />
+            <Setter Property="TextWrapping"
+                    Value="NoWrap" />
+            <Setter Property="TextAlignment"
+                    Value="Center" />
+            <Setter Property="HorizontalAlignment"
+                    Value="Center" />
+            <Setter Property="VerticalAlignment"
+                    Value="Center" />
+        </Style>
+        <Style x:Key="LyricDropShadowPanelStyle"
+               TargetType="toolkit:DropShadowPanel">
+            <Setter Property="Color"
+                    Value="{ThemeResource SystemBaseHighColor}" />
+            <Setter Property="HorizontalAlignment"
+                    Value="Center" />
+            <Setter Property="VerticalAlignment"
+                    Value="Center" />
+            <Setter Property="BlurRadius"
+                    Value="8" />
+            <Setter Property="OffsetX"
+                    Value="0" />
+            <Setter Property="OffsetY"
+                    Value="0" />
+            <Setter Property="OffsetZ"
+                    Value="0" />
+        </Style>
+    </Page.Resources>
 
-  <Grid Background="{ThemeResource ROOTBG}"
-        x:Name="Root">
-    <Grid.RowDefinitions>
-      <RowDefinition Height="*" />
-      <RowDefinition Height="*" />
-      <RowDefinition Height="*" />
-    </Grid.RowDefinitions>
+    <Grid Background="{ThemeResource ROOTBG}"
+          x:Name="Root">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-    <toolkit:DropShadowPanel Opacity="0.33333"
-                             Style="{StaticResource LyricDropShadowPanelStyle}"
-                             Grid.Row="0">
-      <TextBlock Text="{x:Bind Lyric.GetPrevious(Lyric.CurrentIndex),Mode=OneWay}"
-                 Style="{ThemeResource LyricTextBlockStyle}" />
-    </toolkit:DropShadowPanel>
+        <toolkit:DropShadowPanel Opacity="0.33333"
+                                 Style="{StaticResource LyricDropShadowPanelStyle}"
+                                 Grid.Row="0">
+            <TextBlock Text="{x:Bind Lyric.GetPrevious(Lyric.CurrentIndex),Mode=OneWay}"
+                       Style="{ThemeResource LyricTextBlockStyle}" />
+        </toolkit:DropShadowPanel>
 
-    <toolkit:DropShadowPanel Style="{StaticResource LyricDropShadowPanelStyle}"
-                             Grid.Row="1">
-      <TextBlock Text="{x:Bind Lyric.GetCurrent(Lyric.CurrentIndex),Mode=OneWay}"
-                 Style="{ThemeResource LyricTextBlockStyle}" />
-    </toolkit:DropShadowPanel>
+        <toolkit:DropShadowPanel Style="{StaticResource LyricDropShadowPanelStyle}"
+                                 Grid.Row="1">
+            <TextBlock Text="{x:Bind Lyric.GetCurrent(Lyric.CurrentIndex),Mode=OneWay}"
+                       Style="{ThemeResource LyricTextBlockStyle}" />
+        </toolkit:DropShadowPanel>
 
-    <toolkit:DropShadowPanel Opacity="0.33333"
-                             Style="{StaticResource LyricDropShadowPanelStyle}"
-                             Grid.Row="2">
-      <TextBlock Text="{x:Bind Lyric.GetNext(Lyric.CurrentIndex),Mode=OneWay}"
-                 Style="{ThemeResource LyricTextBlockStyle}" />
-    </toolkit:DropShadowPanel>
+        <toolkit:DropShadowPanel Opacity="0.33333"
+                                 Style="{StaticResource LyricDropShadowPanelStyle}"
+                                 Grid.Row="2">
+            <TextBlock Text="{x:Bind Lyric.GetNext(Lyric.CurrentIndex),Mode=OneWay}"
+                       Style="{ThemeResource LyricTextBlockStyle}" />
+        </toolkit:DropShadowPanel>
 
-  </Grid>
+    </Grid>
 </Page>

--- a/Source/Aurora.Music/MainPage.xaml.cs
+++ b/Source/Aurora.Music/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Aurora Studio. All rights reserved.
+// Copyright (c) Aurora Studio. All rights reserved.
 //
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using Aurora.Music.Controls;
@@ -75,17 +75,17 @@ namespace Aurora.Music
                     await Task.Delay(Convert.ToInt32((sleepTime - DateTime.Now).TotalMilliseconds));
                     switch (sleepAction)
                     {
-                    case SleepAction.Pause:
-                        MainPageViewModel.Current.PlayPause.Execute();
-                        break;
-                    case SleepAction.Stop:
-                        MainPageViewModel.Current.Stop.Execute();
-                        break;
-                    case SleepAction.Shutdown:
-                        Application.Current.Exit();
-                        break;
-                    default:
-                        break;
+                        case SleepAction.Pause:
+                            MainPageViewModel.Current.PlayPause.Execute();
+                            break;
+                        case SleepAction.Stop:
+                            MainPageViewModel.Current.Stop.Execute();
+                            break;
+                        case SleepAction.Shutdown:
+                            Application.Current.Exit();
+                            break;
+                        default:
+                            break;
                     }
                 });
             }, period.TotalSeconds < 0 ? TimeSpan.FromSeconds(1) : period, destroy =>
@@ -759,25 +759,25 @@ namespace Aurora.Music
             var result = await dialog.ShowAsync();
             switch (result)
             {
-            case ContentDialogResult.None:
-                break;
-            case ContentDialogResult.Primary:
-                var folder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Music", CreationCollisionOption.OpenIfExists);
-                foreach (var item in files)
-                {
-                    try
+                case ContentDialogResult.None:
+                    break;
+                case ContentDialogResult.Primary:
+                    var folder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Music", CreationCollisionOption.OpenIfExists);
+                    foreach (var item in files)
                     {
-                        await item.CopyAsync(folder, item.Name, NameCollisionOption.ReplaceExisting);
+                        try
+                        {
+                            await item.CopyAsync(folder, item.Name, NameCollisionOption.ReplaceExisting);
+                        }
+                        catch (Exception)
+                        {
+                        }
                     }
-                    catch (Exception)
-                    {
-                    }
-                }
-                break;
-            case ContentDialogResult.Secondary:
-                break;
-            default:
-                break;
+                    break;
+                case ContentDialogResult.Secondary:
+                    break;
+                default:
+                    break;
             }
         }
 
@@ -824,11 +824,11 @@ namespace Aurora.Music
         {
             switch (SearchButton.Visibility)
             {
-            case Visibility.Collapsed:
-                SearchBoxCollapse.Begin();
-                return;
-            default:
-                break;
+                case Visibility.Collapsed:
+                    SearchBoxCollapse.Begin();
+                    return;
+                default:
+                    break;
             }
 
             SearchBoxShow.Begin();
@@ -940,21 +940,21 @@ namespace Aurora.Music
             {
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    await Context.InstantPlay(await g.GetSongsAsync());
-                    break;
-                case SongViewModel song:
-                    await Context.InstantPlay(new List<Song>() { song.Song });
-                    break;
-                case AlbumViewModel album:
-                    await Context.InstantPlay(await album.GetSongsAsync());
-                    break;
-                case ArtistViewModel artist:
-                    await Context.InstantPlay(await artist.GetSongsAsync());
-                    break;
+                    case GenericMusicItemViewModel g:
+                        await Context.InstantPlay(await g.GetSongsAsync());
+                        break;
+                    case SongViewModel song:
+                        await Context.InstantPlay(new List<Song>() { song.Song });
+                        break;
+                    case AlbumViewModel album:
+                        await Context.InstantPlay(await album.GetSongsAsync());
+                        break;
+                    case ArtistViewModel artist:
+                        await Context.InstantPlay(await artist.GetSongsAsync());
+                        break;
 
-                default:
-                    break;
+                    default:
+                        break;
                 }
             }
         }
@@ -964,20 +964,20 @@ namespace Aurora.Music
             {
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    await Context.PlayNext(await g.GetSongsAsync());
-                    break;
-                case SongViewModel song:
-                    await Context.PlayNext(new List<Song>() { song.Song });
-                    break;
-                case AlbumViewModel album:
-                    await Context.PlayNext(await album.GetSongsAsync());
-                    break;
-                case ArtistViewModel artist:
-                    await Context.PlayNext(await artist.GetSongsAsync());
-                    break;
-                default:
-                    break;
+                    case GenericMusicItemViewModel g:
+                        await Context.PlayNext(await g.GetSongsAsync());
+                        break;
+                    case SongViewModel song:
+                        await Context.PlayNext(new List<Song>() { song.Song });
+                        break;
+                    case AlbumViewModel album:
+                        await Context.PlayNext(await album.GetSongsAsync());
+                        break;
+                    case ArtistViewModel artist:
+                        await Context.PlayNext(await artist.GetSongsAsync());
+                        break;
+                    default:
+                        break;
                 }
             }
         }
@@ -988,20 +988,20 @@ namespace Aurora.Music
                 AlbumViewModel viewModel = null;
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    viewModel = await g.FindAssociatedAlbumAsync();
-                    break;
-                case SongViewModel song:
-                    viewModel = await song.GetAlbumAsync();
-                    break;
-                case AlbumViewModel album:
-                    viewModel = album;
-                    break;
-                case ArtistViewModel artist:
-                    break;
+                    case GenericMusicItemViewModel g:
+                        viewModel = await g.FindAssociatedAlbumAsync();
+                        break;
+                    case SongViewModel song:
+                        viewModel = await song.GetAlbumAsync();
+                        break;
+                    case AlbumViewModel album:
+                        viewModel = album;
+                        break;
+                    case ArtistViewModel artist:
+                        break;
 
-                default:
-                    break;
+                    default:
+                        break;
                 }
                 var dialog = new AlbumViewDialog(viewModel);
                 await dialog.ShowAsync();
@@ -1024,24 +1024,24 @@ namespace Aurora.Music
             {
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    shareTitle = $"I'm sharing {g.Title} to you";
-                    shareDesc = $"{g.ToString()}";
-                    break;
-                case SongViewModel song:
-                    shareTitle = $"I'm sharing {song.Title} to you";
-                    shareDesc = $"{song.ToString()}";
-                    break;
-                case AlbumViewModel album:
-                    shareTitle = $"I'm sharing {album.Name} to you";
-                    shareDesc = string.Format(Consts.Localizer.GetString("TileDesc"), album.Name, album.GetFormattedArtists());
-                    break;
-                case ArtistViewModel artist:
-                    shareTitle = $"I'm sharing {artist.Name} to you";
-                    shareDesc = $"";
-                    break;
-                default:
-                    break;
+                    case GenericMusicItemViewModel g:
+                        shareTitle = $"I'm sharing {g.Title} to you";
+                        shareDesc = $"{g.ToString()}";
+                        break;
+                    case SongViewModel song:
+                        shareTitle = $"I'm sharing {song.Title} to you";
+                        shareDesc = $"{song.ToString()}";
+                        break;
+                    case AlbumViewModel album:
+                        shareTitle = $"I'm sharing {album.Name} to you";
+                        shareDesc = string.Format(Consts.Localizer.GetString("TileDesc"), album.Name, album.GetFormattedArtists());
+                        break;
+                    case ArtistViewModel artist:
+                        shareTitle = $"I'm sharing {artist.Name} to you";
+                        shareDesc = $"";
+                        break;
+                    default:
+                        break;
                 }
             }
             DataTransferManager.ShowShareUI();
@@ -1067,41 +1067,41 @@ namespace Aurora.Music
             {
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    switch (g.InnerType)
-                    {
-                    case MediaType.Song:
-                        if (g.IsOnline)
+                    case GenericMusicItemViewModel g:
+                        switch (g.InnerType)
                         {
-                            throw new InvalidOperationException("Can't open an online file");
+                            case MediaType.Song:
+                                if (g.IsOnline)
+                                {
+                                    throw new InvalidOperationException("Can't open an online file");
+                                }
+                                await new TagDialog(new SongViewModel((await g.GetSongsAsync())[0])).ShowAsync();
+                                break;
+                            case MediaType.Album:
+                                PopMessage("Not support for this kind");
+                                break;
+                            case MediaType.PlayList:
+                                PopMessage("Not support for this kind");
+                                break;
+                            case MediaType.Artist:
+                                PopMessage("Not support for this kind");
+                                break;
+                            default:
+                                break;
                         }
-                        await new TagDialog(new SongViewModel((await g.GetSongsAsync())[0])).ShowAsync();
                         break;
-                    case MediaType.Album:
+                    case SongViewModel song:
+                        await new TagDialog(song).ShowAsync();
+                        break;
+                    case AlbumViewModel album:
                         PopMessage("Not support for this kind");
                         break;
-                    case MediaType.PlayList:
+                    case ArtistViewModel artist:
                         PopMessage("Not support for this kind");
                         break;
-                    case MediaType.Artist:
-                        PopMessage("Not support for this kind");
-                        break;
+
                     default:
                         break;
-                    }
-                    break;
-                case SongViewModel song:
-                    await new TagDialog(song).ShowAsync();
-                    break;
-                case AlbumViewModel album:
-                    PopMessage("Not support for this kind");
-                    break;
-                case ArtistViewModel artist:
-                    PopMessage("Not support for this kind");
-                    break;
-
-                default:
-                    break;
                 }
             }
         }
@@ -1112,36 +1112,36 @@ namespace Aurora.Music
                 string path = null;
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    switch (g.InnerType)
-                    {
-                    case MediaType.Song:
-                        if (g.IsOnline)
+                    case GenericMusicItemViewModel g:
+                        switch (g.InnerType)
                         {
-                            throw new InvalidOperationException("Can't open an online file");
+                            case MediaType.Song:
+                                if (g.IsOnline)
+                                {
+                                    throw new InvalidOperationException("Can't open an online file");
+                                }
+                                path = (await g.GetSongsAsync())[0].FilePath;
+                                break;
+                            case MediaType.Album:
+                                break;
+                            case MediaType.PlayList:
+                                break;
+                            case MediaType.Artist:
+                                break;
+                            default:
+                                break;
                         }
-                        path = (await g.GetSongsAsync())[0].FilePath;
                         break;
-                    case MediaType.Album:
+                    case SongViewModel song:
+                        path = song.FilePath;
                         break;
-                    case MediaType.PlayList:
+                    case AlbumViewModel album:
                         break;
-                    case MediaType.Artist:
+                    case ArtistViewModel artist:
                         break;
+
                     default:
                         break;
-                    }
-                    break;
-                case SongViewModel song:
-                    path = song.FilePath;
-                    break;
-                case AlbumViewModel album:
-                    break;
-                case ArtistViewModel artist:
-                    break;
-
-                default:
-                    break;
                 }
                 if (!path.IsNullorEmpty())
                 {
@@ -1159,38 +1159,38 @@ namespace Aurora.Music
                 List<string> paths = new List<string>();
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    switch (g.InnerType)
-                    {
-                    case MediaType.Song:
-                        if (g.IsOnline)
+                    case GenericMusicItemViewModel g:
+                        switch (g.InnerType)
                         {
-                            throw new InvalidOperationException("Can't open an online file");
+                            case MediaType.Song:
+                                if (g.IsOnline)
+                                {
+                                    throw new InvalidOperationException("Can't open an online file");
+                                }
+                                paths.Add((await g.GetSongsAsync())[0].FilePath);
+                                break;
+                            case MediaType.Album:
+                                paths.AddRange((await g.GetSongsAsync()).Select(x => x.FilePath));
+                                break;
+                            case MediaType.PlayList:
+                                break;
+                            case MediaType.Artist:
+                                break;
+                            default:
+                                break;
                         }
-                        paths.Add((await g.GetSongsAsync())[0].FilePath);
                         break;
-                    case MediaType.Album:
-                        paths.AddRange((await g.GetSongsAsync()).Select(x => x.FilePath));
+                    case SongViewModel song:
+                        paths.Add(song.FilePath);
                         break;
-                    case MediaType.PlayList:
+                    case AlbumViewModel album:
+                        paths.AddRange((await album.GetSongsAsync()).Select(x => x.FilePath));
                         break;
-                    case MediaType.Artist:
+                    case ArtistViewModel artist:
                         break;
+
                     default:
                         break;
-                    }
-                    break;
-                case SongViewModel song:
-                    paths.Add(song.FilePath);
-                    break;
-                case AlbumViewModel album:
-                    paths.AddRange((await album.GetSongsAsync()).Select(x => x.FilePath));
-                    break;
-                case ArtistViewModel artist:
-                    break;
-
-                default:
-                    break;
                 }
                 foreach (var path in paths)
                 {
@@ -1217,38 +1217,38 @@ namespace Aurora.Music
                 List<string> paths = new List<string>();
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    switch (g.InnerType)
-                    {
-                    case MediaType.Song:
-                        if (g.IsOnline)
+                    case GenericMusicItemViewModel g:
+                        switch (g.InnerType)
                         {
-                            throw new InvalidOperationException("Can't open an online file");
+                            case MediaType.Song:
+                                if (g.IsOnline)
+                                {
+                                    throw new InvalidOperationException("Can't open an online file");
+                                }
+                                paths.Add((await g.GetSongsAsync())[0].FilePath);
+                                break;
+                            case MediaType.Album:
+                                paths.AddRange((await g.GetSongsAsync()).Select(x => x.FilePath));
+                                break;
+                            case MediaType.PlayList:
+                                break;
+                            case MediaType.Artist:
+                                break;
+                            default:
+                                break;
                         }
-                        paths.Add((await g.GetSongsAsync())[0].FilePath);
                         break;
-                    case MediaType.Album:
-                        paths.AddRange((await g.GetSongsAsync()).Select(x => x.FilePath));
+                    case SongViewModel song:
+                        paths.Add(song.FilePath);
                         break;
-                    case MediaType.PlayList:
+                    case AlbumViewModel album:
+                        paths.AddRange((await album.GetSongsAsync()).Select(x => x.FilePath));
                         break;
-                    case MediaType.Artist:
+                    case ArtistViewModel artist:
                         break;
+
                     default:
                         break;
-                    }
-                    break;
-                case SongViewModel song:
-                    paths.Add(song.FilePath);
-                    break;
-                case AlbumViewModel album:
-                    paths.AddRange((await album.GetSongsAsync()).Select(x => x.FilePath));
-                    break;
-                case ArtistViewModel artist:
-                    break;
-
-                default:
-                    break;
                 }
                 foreach (var path in paths)
                 {
@@ -1274,20 +1274,20 @@ namespace Aurora.Music
                 AddPlayList dialog;
                 switch (s.Content)
                 {
-                case GenericMusicItemViewModel g:
-                    dialog = new AddPlayList((await g.GetSongsAsync()).Select(x => x.ID));
-                    break;
-                case SongViewModel song:
-                    dialog = new AddPlayList(song.ID);
-                    break;
-                case AlbumViewModel album:
-                    dialog = new AddPlayList((await album.GetSongsAsync()).Select(x => x.ID));
-                    break;
-                case ArtistViewModel artist:
-                    dialog = new AddPlayList((await artist.GetSongsAsync()).Select(x => x.ID));
-                    break;
-                default:
-                    throw new OperationCanceledException();
+                    case GenericMusicItemViewModel g:
+                        dialog = new AddPlayList((await g.GetSongsAsync()).Select(x => x.ID));
+                        break;
+                    case SongViewModel song:
+                        dialog = new AddPlayList(song.ID);
+                        break;
+                    case AlbumViewModel album:
+                        dialog = new AddPlayList((await album.GetSongsAsync()).Select(x => x.ID));
+                        break;
+                    case ArtistViewModel artist:
+                        dialog = new AddPlayList((await artist.GetSongsAsync()).Select(x => x.ID));
+                        break;
+                    default:
+                        throw new OperationCanceledException();
                 }
                 await dialog.ShowAsync();
             }

--- a/Source/Aurora.Music/MainPage.xaml.cs
+++ b/Source/Aurora.Music/MainPage.xaml.cs
@@ -75,17 +75,17 @@ namespace Aurora.Music
                     await Task.Delay(Convert.ToInt32((sleepTime - DateTime.Now).TotalMilliseconds));
                     switch (sleepAction)
                     {
-                        case SleepAction.Pause:
-                            MainPageViewModel.Current.PlayPause.Execute();
-                            break;
-                        case SleepAction.Stop:
-                            MainPageViewModel.Current.Stop.Execute();
-                            break;
-                        case SleepAction.Shutdown:
-                            Application.Current.Exit();
-                            break;
-                        default:
-                            break;
+                    case SleepAction.Pause:
+                        MainPageViewModel.Current.PlayPause.Execute();
+                        break;
+                    case SleepAction.Stop:
+                        MainPageViewModel.Current.Stop.Execute();
+                        break;
+                    case SleepAction.Shutdown:
+                        Application.Current.Exit();
+                        break;
+                    default:
+                        break;
                     }
                 });
             }, period.TotalSeconds < 0 ? TimeSpan.FromSeconds(1) : period, destroy =>
@@ -407,6 +407,7 @@ namespace Aurora.Music
                 Window.Current.Content = frame;
                 Window.Current.Activate();
                 CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
+                Window.Current.SetTitleBar(frame);
                 ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
                 titleBar.ButtonBackgroundColor = Colors.Transparent;
                 titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
@@ -758,25 +759,25 @@ namespace Aurora.Music
             var result = await dialog.ShowAsync();
             switch (result)
             {
-                case ContentDialogResult.None:
-                    break;
-                case ContentDialogResult.Primary:
-                    var folder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Music", CreationCollisionOption.OpenIfExists);
-                    foreach (var item in files)
+            case ContentDialogResult.None:
+                break;
+            case ContentDialogResult.Primary:
+                var folder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Music", CreationCollisionOption.OpenIfExists);
+                foreach (var item in files)
+                {
+                    try
                     {
-                        try
-                        {
-                            await item.CopyAsync(folder, item.Name, NameCollisionOption.ReplaceExisting);
-                        }
-                        catch (Exception)
-                        {
-                        }
+                        await item.CopyAsync(folder, item.Name, NameCollisionOption.ReplaceExisting);
                     }
-                    break;
-                case ContentDialogResult.Secondary:
-                    break;
-                default:
-                    break;
+                    catch (Exception)
+                    {
+                    }
+                }
+                break;
+            case ContentDialogResult.Secondary:
+                break;
+            default:
+                break;
             }
         }
 
@@ -823,11 +824,11 @@ namespace Aurora.Music
         {
             switch (SearchButton.Visibility)
             {
-                case Visibility.Collapsed:
-                    SearchBoxCollapse.Begin();
-                    return;
-                default:
-                    break;
+            case Visibility.Collapsed:
+                SearchBoxCollapse.Begin();
+                return;
+            default:
+                break;
             }
 
             SearchBoxShow.Begin();
@@ -939,21 +940,21 @@ namespace Aurora.Music
             {
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        await Context.InstantPlay(await g.GetSongsAsync());
-                        break;
-                    case SongViewModel song:
-                        await Context.InstantPlay(new List<Song>() { song.Song });
-                        break;
-                    case AlbumViewModel album:
-                        await Context.InstantPlay(await album.GetSongsAsync());
-                        break;
-                    case ArtistViewModel artist:
-                        await Context.InstantPlay(await artist.GetSongsAsync());
-                        break;
+                case GenericMusicItemViewModel g:
+                    await Context.InstantPlay(await g.GetSongsAsync());
+                    break;
+                case SongViewModel song:
+                    await Context.InstantPlay(new List<Song>() { song.Song });
+                    break;
+                case AlbumViewModel album:
+                    await Context.InstantPlay(await album.GetSongsAsync());
+                    break;
+                case ArtistViewModel artist:
+                    await Context.InstantPlay(await artist.GetSongsAsync());
+                    break;
 
-                    default:
-                        break;
+                default:
+                    break;
                 }
             }
         }
@@ -963,20 +964,20 @@ namespace Aurora.Music
             {
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        await Context.PlayNext(await g.GetSongsAsync());
-                        break;
-                    case SongViewModel song:
-                        await Context.PlayNext(new List<Song>() { song.Song });
-                        break;
-                    case AlbumViewModel album:
-                        await Context.PlayNext(await album.GetSongsAsync());
-                        break;
-                    case ArtistViewModel artist:
-                        await Context.PlayNext(await artist.GetSongsAsync());
-                        break;
-                    default:
-                        break;
+                case GenericMusicItemViewModel g:
+                    await Context.PlayNext(await g.GetSongsAsync());
+                    break;
+                case SongViewModel song:
+                    await Context.PlayNext(new List<Song>() { song.Song });
+                    break;
+                case AlbumViewModel album:
+                    await Context.PlayNext(await album.GetSongsAsync());
+                    break;
+                case ArtistViewModel artist:
+                    await Context.PlayNext(await artist.GetSongsAsync());
+                    break;
+                default:
+                    break;
                 }
             }
         }
@@ -987,20 +988,20 @@ namespace Aurora.Music
                 AlbumViewModel viewModel = null;
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        viewModel = await g.FindAssociatedAlbumAsync();
-                        break;
-                    case SongViewModel song:
-                        viewModel = await song.GetAlbumAsync();
-                        break;
-                    case AlbumViewModel album:
-                        viewModel = album;
-                        break;
-                    case ArtistViewModel artist:
-                        break;
+                case GenericMusicItemViewModel g:
+                    viewModel = await g.FindAssociatedAlbumAsync();
+                    break;
+                case SongViewModel song:
+                    viewModel = await song.GetAlbumAsync();
+                    break;
+                case AlbumViewModel album:
+                    viewModel = album;
+                    break;
+                case ArtistViewModel artist:
+                    break;
 
-                    default:
-                        break;
+                default:
+                    break;
                 }
                 var dialog = new AlbumViewDialog(viewModel);
                 await dialog.ShowAsync();
@@ -1023,24 +1024,24 @@ namespace Aurora.Music
             {
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        shareTitle = $"I'm sharing {g.Title} to you";
-                        shareDesc = $"{g.ToString()}";
-                        break;
-                    case SongViewModel song:
-                        shareTitle = $"I'm sharing {song.Title} to you";
-                        shareDesc = $"{song.ToString()}";
-                        break;
-                    case AlbumViewModel album:
-                        shareTitle = $"I'm sharing {album.Name} to you";
-                        shareDesc = string.Format(Consts.Localizer.GetString("TileDesc"), album.Name, album.GetFormattedArtists());
-                        break;
-                    case ArtistViewModel artist:
-                        shareTitle = $"I'm sharing {artist.Name} to you";
-                        shareDesc = $"";
-                        break;
-                    default:
-                        break;
+                case GenericMusicItemViewModel g:
+                    shareTitle = $"I'm sharing {g.Title} to you";
+                    shareDesc = $"{g.ToString()}";
+                    break;
+                case SongViewModel song:
+                    shareTitle = $"I'm sharing {song.Title} to you";
+                    shareDesc = $"{song.ToString()}";
+                    break;
+                case AlbumViewModel album:
+                    shareTitle = $"I'm sharing {album.Name} to you";
+                    shareDesc = string.Format(Consts.Localizer.GetString("TileDesc"), album.Name, album.GetFormattedArtists());
+                    break;
+                case ArtistViewModel artist:
+                    shareTitle = $"I'm sharing {artist.Name} to you";
+                    shareDesc = $"";
+                    break;
+                default:
+                    break;
                 }
             }
             DataTransferManager.ShowShareUI();
@@ -1066,41 +1067,41 @@ namespace Aurora.Music
             {
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        switch (g.InnerType)
+                case GenericMusicItemViewModel g:
+                    switch (g.InnerType)
+                    {
+                    case MediaType.Song:
+                        if (g.IsOnline)
                         {
-                            case MediaType.Song:
-                                if (g.IsOnline)
-                                {
-                                    throw new InvalidOperationException("Can't open an online file");
-                                }
-                                await new TagDialog(new SongViewModel((await g.GetSongsAsync())[0])).ShowAsync();
-                                break;
-                            case MediaType.Album:
-                                PopMessage("Not support for this kind");
-                                break;
-                            case MediaType.PlayList:
-                                PopMessage("Not support for this kind");
-                                break;
-                            case MediaType.Artist:
-                                PopMessage("Not support for this kind");
-                                break;
-                            default:
-                                break;
+                            throw new InvalidOperationException("Can't open an online file");
                         }
+                        await new TagDialog(new SongViewModel((await g.GetSongsAsync())[0])).ShowAsync();
                         break;
-                    case SongViewModel song:
-                        await new TagDialog(song).ShowAsync();
-                        break;
-                    case AlbumViewModel album:
+                    case MediaType.Album:
                         PopMessage("Not support for this kind");
                         break;
-                    case ArtistViewModel artist:
+                    case MediaType.PlayList:
                         PopMessage("Not support for this kind");
                         break;
-
+                    case MediaType.Artist:
+                        PopMessage("Not support for this kind");
+                        break;
                     default:
                         break;
+                    }
+                    break;
+                case SongViewModel song:
+                    await new TagDialog(song).ShowAsync();
+                    break;
+                case AlbumViewModel album:
+                    PopMessage("Not support for this kind");
+                    break;
+                case ArtistViewModel artist:
+                    PopMessage("Not support for this kind");
+                    break;
+
+                default:
+                    break;
                 }
             }
         }
@@ -1111,36 +1112,36 @@ namespace Aurora.Music
                 string path = null;
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        switch (g.InnerType)
+                case GenericMusicItemViewModel g:
+                    switch (g.InnerType)
+                    {
+                    case MediaType.Song:
+                        if (g.IsOnline)
                         {
-                            case MediaType.Song:
-                                if (g.IsOnline)
-                                {
-                                    throw new InvalidOperationException("Can't open an online file");
-                                }
-                                path = (await g.GetSongsAsync())[0].FilePath;
-                                break;
-                            case MediaType.Album:
-                                break;
-                            case MediaType.PlayList:
-                                break;
-                            case MediaType.Artist:
-                                break;
-                            default:
-                                break;
+                            throw new InvalidOperationException("Can't open an online file");
                         }
+                        path = (await g.GetSongsAsync())[0].FilePath;
                         break;
-                    case SongViewModel song:
-                        path = song.FilePath;
+                    case MediaType.Album:
                         break;
-                    case AlbumViewModel album:
+                    case MediaType.PlayList:
                         break;
-                    case ArtistViewModel artist:
+                    case MediaType.Artist:
                         break;
-
                     default:
                         break;
+                    }
+                    break;
+                case SongViewModel song:
+                    path = song.FilePath;
+                    break;
+                case AlbumViewModel album:
+                    break;
+                case ArtistViewModel artist:
+                    break;
+
+                default:
+                    break;
                 }
                 if (!path.IsNullorEmpty())
                 {
@@ -1158,38 +1159,38 @@ namespace Aurora.Music
                 List<string> paths = new List<string>();
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        switch (g.InnerType)
+                case GenericMusicItemViewModel g:
+                    switch (g.InnerType)
+                    {
+                    case MediaType.Song:
+                        if (g.IsOnline)
                         {
-                            case MediaType.Song:
-                                if (g.IsOnline)
-                                {
-                                    throw new InvalidOperationException("Can't open an online file");
-                                }
-                                paths.Add((await g.GetSongsAsync())[0].FilePath);
-                                break;
-                            case MediaType.Album:
-                                paths.AddRange((await g.GetSongsAsync()).Select(x => x.FilePath));
-                                break;
-                            case MediaType.PlayList:
-                                break;
-                            case MediaType.Artist:
-                                break;
-                            default:
-                                break;
+                            throw new InvalidOperationException("Can't open an online file");
                         }
+                        paths.Add((await g.GetSongsAsync())[0].FilePath);
                         break;
-                    case SongViewModel song:
-                        paths.Add(song.FilePath);
+                    case MediaType.Album:
+                        paths.AddRange((await g.GetSongsAsync()).Select(x => x.FilePath));
                         break;
-                    case AlbumViewModel album:
-                        paths.AddRange((await album.GetSongsAsync()).Select(x => x.FilePath));
+                    case MediaType.PlayList:
                         break;
-                    case ArtistViewModel artist:
+                    case MediaType.Artist:
                         break;
-
                     default:
                         break;
+                    }
+                    break;
+                case SongViewModel song:
+                    paths.Add(song.FilePath);
+                    break;
+                case AlbumViewModel album:
+                    paths.AddRange((await album.GetSongsAsync()).Select(x => x.FilePath));
+                    break;
+                case ArtistViewModel artist:
+                    break;
+
+                default:
+                    break;
                 }
                 foreach (var path in paths)
                 {
@@ -1216,38 +1217,38 @@ namespace Aurora.Music
                 List<string> paths = new List<string>();
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        switch (g.InnerType)
+                case GenericMusicItemViewModel g:
+                    switch (g.InnerType)
+                    {
+                    case MediaType.Song:
+                        if (g.IsOnline)
                         {
-                            case MediaType.Song:
-                                if (g.IsOnline)
-                                {
-                                    throw new InvalidOperationException("Can't open an online file");
-                                }
-                                paths.Add((await g.GetSongsAsync())[0].FilePath);
-                                break;
-                            case MediaType.Album:
-                                paths.AddRange((await g.GetSongsAsync()).Select(x => x.FilePath));
-                                break;
-                            case MediaType.PlayList:
-                                break;
-                            case MediaType.Artist:
-                                break;
-                            default:
-                                break;
+                            throw new InvalidOperationException("Can't open an online file");
                         }
+                        paths.Add((await g.GetSongsAsync())[0].FilePath);
                         break;
-                    case SongViewModel song:
-                        paths.Add(song.FilePath);
+                    case MediaType.Album:
+                        paths.AddRange((await g.GetSongsAsync()).Select(x => x.FilePath));
                         break;
-                    case AlbumViewModel album:
-                        paths.AddRange((await album.GetSongsAsync()).Select(x => x.FilePath));
+                    case MediaType.PlayList:
                         break;
-                    case ArtistViewModel artist:
+                    case MediaType.Artist:
                         break;
-
                     default:
                         break;
+                    }
+                    break;
+                case SongViewModel song:
+                    paths.Add(song.FilePath);
+                    break;
+                case AlbumViewModel album:
+                    paths.AddRange((await album.GetSongsAsync()).Select(x => x.FilePath));
+                    break;
+                case ArtistViewModel artist:
+                    break;
+
+                default:
+                    break;
                 }
                 foreach (var path in paths)
                 {
@@ -1273,20 +1274,20 @@ namespace Aurora.Music
                 AddPlayList dialog;
                 switch (s.Content)
                 {
-                    case GenericMusicItemViewModel g:
-                        dialog = new AddPlayList((await g.GetSongsAsync()).Select(x => x.ID));
-                        break;
-                    case SongViewModel song:
-                        dialog = new AddPlayList(song.ID);
-                        break;
-                    case AlbumViewModel album:
-                        dialog = new AddPlayList((await album.GetSongsAsync()).Select(x => x.ID));
-                        break;
-                    case ArtistViewModel artist:
-                        dialog = new AddPlayList((await artist.GetSongsAsync()).Select(x => x.ID));
-                        break;
-                    default:
-                        throw new OperationCanceledException();
+                case GenericMusicItemViewModel g:
+                    dialog = new AddPlayList((await g.GetSongsAsync()).Select(x => x.ID));
+                    break;
+                case SongViewModel song:
+                    dialog = new AddPlayList(song.ID);
+                    break;
+                case AlbumViewModel album:
+                    dialog = new AddPlayList((await album.GetSongsAsync()).Select(x => x.ID));
+                    break;
+                case ArtistViewModel artist:
+                    dialog = new AddPlayList((await artist.GetSongsAsync()).Select(x => x.ID));
+                    break;
+                default:
+                    throw new OperationCanceledException();
                 }
                 await dialog.ShowAsync();
             }

--- a/Source/LrcParser/Lyric.cs
+++ b/Source/LrcParser/Lyric.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,7 +6,6 @@ namespace LrcParser
 {
     public class Lyric
     {
-
         public Lyric(IOrderedEnumerable<Slice> orderedEnumerable, List<KeyValuePair<string, string>> enumerable)
         {
             this.Slices = orderedEnumerable;
@@ -15,7 +14,7 @@ namespace LrcParser
             {
                 if (item.Key.Equals("offset", StringComparison.CurrentCultureIgnoreCase))
                 {
-                    if (int.TryParse(item.Value, out int i))
+                    if (double.TryParse(item.Value, out double i))
                     {
                         Offset = TimeSpan.FromMilliseconds(i);
                         AddtionalInfo.Remove(item);

--- a/Source/LrcParser/Lyric.cs
+++ b/Source/LrcParser/Lyric.cs
@@ -6,9 +6,9 @@ namespace LrcParser
 {
     public class Lyric
     {
-        public Lyric(IOrderedEnumerable<Slice> orderedEnumerable, List<KeyValuePair<string, string>> enumerable)
+        internal Lyric(IOrderedEnumerable<Slice> orderedEnumerable, List<KeyValuePair<string, string>> enumerable)
         {
-            this.Slices = orderedEnumerable;
+            this.Slices = orderedEnumerable.ToList();
             this.AddtionalInfo = enumerable;
             foreach (var item in AddtionalInfo)
             {
@@ -28,15 +28,19 @@ namespace LrcParser
         {
             var sl = s.Split('\n');
 
-            Slices = sl.Select(x => new Slice
+            Slices = new List<Slice>(sl.Length);
+            for (int i = 0; i < sl.Length; i++)
             {
-                Offset = TimeSpan.FromMilliseconds(duration.TotalMilliseconds * (Array.IndexOf(sl, x) / (double)sl.Length)),
-                Content = x
-            }).OrderBy(x => 1);
+                Slices.Add(new Slice
+                {
+                    Offset = TimeSpan.FromMilliseconds(duration.TotalMilliseconds * i / sl.Length),
+                    Content = sl[i],
+                });
+            }
             AddtionalInfo = null;
         }
 
-        public IOrderedEnumerable<Slice> Slices { get; set; }
+        public List<Slice> Slices { get; set; }
         public List<KeyValuePair<string, string>> AddtionalInfo { get; set; }
 
         public TimeSpan Offset { get; set; }

--- a/Source/LrcParser/Parser.cs
+++ b/Source/LrcParser/Parser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -56,9 +56,18 @@ namespace LrcParser
             return list;
         }
 
+        private static string[] acceptedTimeFormats = new[]
+        {
+            @"m\:s",
+            @"m\:s\.f",
+            @"m\:s\.ff",
+            @"m\:s\.fff",
+            @"m\:s\.ffff",
+        };
+
         public static IEnumerable<Slice> CreateSlice(IList<KeyValuePair<string, string>> slices)
         {
-            var timewithbrace = new Regex(@"\[\d+:\d+.\d+\]");
+            var timewithbrace = new Regex(@"\[\d+:\d+(|.\d+)\]");
             var list = new List<Slice>();
             for (int i = 0; i < slices.Count; i++)
             {
@@ -66,7 +75,7 @@ namespace LrcParser
                 if (time.Success)
                 {
                     var t = time.Value.Substring(1, time.Value.Length - 2);
-                    if (TimeSpan.TryParseExact(t, @"mm\:ss\.ff", null, out TimeSpan p))
+                    if (TimeSpan.TryParseExact(t, acceptedTimeFormats, null, out TimeSpan p))
                     {
                         for (int j = i; j < slices.Count; j++)
                         {

--- a/Source/URIViewer/MainPage.xaml.cs
+++ b/Source/URIViewer/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Source/URIViewer/MainPage.xaml.cs
+++ b/Source/URIViewer/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -33,7 +33,7 @@ namespace URIViewer
             {
                 var uri = new Uri((sender as TextBox).Text);
 
-                Main.Text = uri.AbsolutePath; Main.Text += Environment.NewLine;
+                Main.Text = $"AbsolutePath: {uri.AbsolutePath}{Environment.NewLine}";
 
                 Main.Text += $"AbsoluteUri: {uri.AbsoluteUri}{Environment.NewLine}";
 
@@ -81,6 +81,7 @@ namespace URIViewer
             }
             catch (Exception)
             {
+                Main.Text = "";
             }
 
         }


### PR DESCRIPTION
1. 歌词窗口直接以 `Frame` 作为标题栏，使整个窗口可以拖动
2. `LyricView` 使用样式
3. `CompactOverlayPanel` 使用背景层作为标题栏
4. `CompactOverlayPanel` 中为 `ButtonPanel` 增加 `ScrollViewer`
5. 添加 `.editorconfig` 配置文件